### PR TITLE
Add Config.toml to tests of smartconfig template

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,4 +25,3 @@ replay_pid*
 
 # Ballerina
 target
-Config.toml

--- a/r4/smartconfig/tests/Config.toml
+++ b/r4/smartconfig/tests/Config.toml
@@ -1,0 +1,48 @@
+[configs]
+discoveryEndpoint = "https://api.asgardeo.io/t/bifrost/oauth2/token/.well-known/openid-configuration"
+
+[configs.smartConfiguration]
+tokenEndpoint = "<TOKEN_ENDPOINT>"
+introspectionEndpoint = "<INTROSPECTION_ENDPOINT>"
+codeChallengeMethodsSupported = ["S256"]
+grantTypesSupported = ["authorization_code"]
+revocationEndpoint = "<REVOCATION_ENDPOINT>"
+tokenEndpointAuthMethodsSupported = ["private_key_jwt", "client_secret_basic"]
+tokenEndpointAuthSigningAlgValuesSupported = ["RS384","ES384"]
+scopesSupported = [
+    "openid",
+    "fhirUser",
+    "launch",
+    "launch/patient",
+    "patient/*.cruds",
+    "user/*.cruds",
+    "offline_access",
+]
+responseTypesSupported = [
+    "code",
+    "id_token",
+    "token",
+    "device",
+    "id_token token"
+]
+capabilities = [
+    "launch-ehr",
+    "launch-standalone",
+    "client-public",
+    "client-confidential-symmetric",
+    "client-confidential-asymmetric",
+    "context-passthrough-banner",
+    "context-passthrough-style",
+    "context-ehr-patient",
+    "context-ehr-encounter",
+    "context-standalone-patient",
+    "context-standalone-encounter",
+    "permission-offline",
+    "permission-patient",
+    "permission-user",
+    "permission-v2",
+    "authorize-post"
+]
+
+[ballerina.log]
+level = "DEBUG"


### PR DESCRIPTION
## Purpose
> Fix error while running tests in smartconfig template
```
error: value not provided for required configurable variable 'configs'
        at ballerinax/health.fhir.templates.r4.smartconfiguration:1.0.2-snapshot(smart_configuration_generator.bal:17)
error: there are test failures
```

## Goals
> Fix test failure in CI workflow

## Approach
> Add Config.toml of smartconfig template to its tests subdirectory

## Concerns
> Remove Config.toml entry from .gitignore