### PR TITLE
Disable failing tests in repository-sync template

### DIFF
--- a/r4/repository-sync/tests/client_util_test.bal
+++ b/r4/repository-sync/tests/client_util_test.bal
@@ -19,7 +19,7 @@ import ballerina/time;
 
 import ballerinax/health.fhir.r4;
 
-@test:Config {enable: true}
+@test:Config {enable: false}
 function testFetchLastInvocationTime() {
     time:Utc|error lastInvocationTime = fetchLastInvocationTime();
     if (lastInvocationTime is error) {
@@ -28,7 +28,7 @@ function testFetchLastInvocationTime() {
     test:assertTrue(true);
 }
 
-@test:Config {enable: true}
+@test:Config {enable: false}
 function testPushCurrentInvocationTime() {
     time:Utc now = time:utcNow();
     error? lastInvocationTime = pushCurrentInvocationTime(now);


### PR DESCRIPTION
## Purpose
> Disable unit tests written for functions to be implemented by the integration developer in repository-sync template

## Goals
> Fix test failure in CI workflow

## Approach
> Disable unit tests of unimplemented methods using annotation
```
@test:Config {enable: false}
```
