### PR TITLE
Implement CI-CD pipelines for templates

### DIFF
--- a/.github/workflows/cd-athena.yml
+++ b/.github/workflows/cd-athena.yml
@@ -1,0 +1,140 @@
+name: CD - Athena
+
+on:
+  workflow_dispatch:
+    inputs:
+      bal_central_environment:
+        description: Ballerina Central Environment
+        type: choice
+        options:
+        - STAGE
+        - DEV
+        - PROD
+        required: true
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    env:
+      JAVA_OPTS: -Xmx4G
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Ballerina Build Athena
+        uses: ballerina-platform/ballerina-action@2201.6.0
+        with:
+          args:
+            pack
+        env:
+          WORKING_DIR: ./r4/athena
+          JAVA_HOME: /usr/lib/jvm/default-jvm
+
+      - name: Push to Staging Athena
+        if: github.event.inputs.bal_central_environment == 'STAGE'
+        uses: ballerina-platform/ballerina-action@2201.6.0
+        with:
+          args:
+            push
+        env:
+          WORKING_DIR: ./r4/athena
+          JAVA_HOME: /usr/lib/jvm/default-jvm
+          BALLERINA_STAGE_CENTRAL: true
+          BALLERINA_CENTRAL_ACCESS_TOKEN: ${{ secrets.BALLERINA_CENTRAL_STAGE_ACCESS_TOKEN }}
+
+      - name: Push to Dev Athena
+        if: github.event.inputs.bal_central_environment == 'DEV'
+        uses: ballerina-platform/ballerina-action@2201.6.0
+        with:
+          args:
+            push
+        env:
+          WORKING_DIR: ./r4/athena
+          JAVA_HOME: /usr/lib/jvm/default-jvm
+          BALLERINA_DEV_CENTRAL: true
+          BALLERINA_CENTRAL_ACCESS_TOKEN: ${{ secrets.BALLERINA_CENTRAL_DEV_ACCESS_TOKEN }}      
+
+      - name: Push to Prod Athena
+        if: github.event.inputs.bal_central_environment == 'PROD'
+        uses: ballerina-platform/ballerina-action@2201.6.0
+        with:
+          args:
+            push
+        env:
+          WORKING_DIR: ./r4/athena
+          JAVA_HOME: /usr/lib/jvm/default-jvm
+          BALLERINA_CENTRAL_ACCESS_TOKEN: ${{ secrets.BALLERINA_CENTRAL_PROD_ACCESS_TOKEN }}
+
+      - name: Publish Release
+        if: github.event.inputs.bal_central_environment == 'PROD'
+        id: publish_release
+        run: |
+          # Get Branch Name
+          BRANCH_NAME=$(echo ${GITHUB_REF#refs/heads/})
+          echo "BRANCH_NAME=${BRANCH_NAME}" >> $GITHUB_OUTPUT
+          # Release name
+          RELEASE_NAME=${BRANCH_NAME#release-}
+          curl \
+            -s -X POST \
+            -H "Authorization: Bearer ${{ secrets.BALLERINA_BOT_TOKEN }}" \
+            -H "Accept: application/vnd.github.v3+json" \
+            -d '{
+              "tag_name": "'$RELEASE_NAME'",
+              "name": "'$RELEASE_NAME'",
+              "body": "[Automated] Creating tag:  '$RELEASE_NAME'.",
+              "draft": false,
+              "prerelease": false,
+              "target_commitish": "'$BRANCH_NAME'"
+            }' \
+            "https://api.github.com/repos/${{ github.repository }}/releases"
+
+      - name: Update version in Ballerina.toml
+        if: ${{ github.event.inputs.bal_central_environment == 'PROD' }}
+        id: increment_patch_version
+        run: |
+          CURRENT_VERSION=$(grep -Po -m 1 '(?<=version = ")[\d.]+' ./r4/athena/Ballerina.toml)
+          IFS='.' read -ra VERSION_PARTS <<< "$CURRENT_VERSION"
+          PATCH_VERSION=$((VERSION_PARTS[2] + 1))
+          NEW_VERSION="${VERSION_PARTS[0]}.${VERSION_PARTS[1]}.$PATCH_VERSION-snapshot"
+          sed -i "0,/version = \"${CURRENT_VERSION}\"/s//version = \"${NEW_VERSION}\"/" ./r4/athena/Ballerina.toml
+          echo "NEW_VERSION=${NEW_VERSION}" >> $GITHUB_OUTPUT
+          echo "CURRENT_VERSION=${CURRENT_VERSION}" >> $GITHUB_OUTPUT
+
+      - name: Ballerina Build after incrementing version
+        if: ${{ github.event.inputs.bal_central_environment == 'PROD' }}
+        uses: ballerina-platform/ballerina-action@2201.6.0
+        with:
+          args:
+            pack
+        env:
+          WORKING_DIR: ./r4/athena
+          JAVA_HOME: /usr/lib/jvm/default-jvm
+
+      - name: Commit changes and make a PR
+        if: ${{ github.event.inputs.bal_central_environment == 'PROD' }}
+        run: |
+          # Commit changes
+          git config --global user.name ${{ secrets.BALLERINA_BOT_USERNAME }}
+          git config --global user.email ${{ secrets.BALLERINA_BOT_EMAIL }}
+          git add ./r4/athena/Ballerina.toml
+          git add ./r4/athena/Dependencies.toml
+          git commit -m "[Release athena ${{ steps.increment_patch_version.outputs.CURRENT_VERSION }}] Prepare for next dev cycle"
+          git push origin ${{ steps.publish_release.outputs.BRANCH_NAME }}
+          
+          # Set the base and head branches
+          BASE_BRANCH="main"
+          HEAD_BRANCH="${{ steps.publish_release.outputs.BRANCH_NAME }}"
+          # Create the pull request using the GitHub REST API
+          RESPONSE=$(curl -s -X POST \
+            -H "Authorization: Bearer ${{ secrets.BALLERINA_BOT_TOKEN }}" \
+            -H "Accept: application/vnd.github.v3+json" \
+            -d '{
+              "title": "[Release athena ${{ steps.increment_patch_version.outputs.CURRENT_VERSION }}] Prepare for next dev cycle",
+              "body": "",
+              "head": "'"$HEAD_BRANCH"'",
+              "base": "'"$BASE_BRANCH"'"
+            }' \
+            "https://api.github.com/repos/${{ github.repository }}/pulls")
+          # Extract the pull request URL from the response
+          PR_URL=$(echo "$RESPONSE" | jq -r '.html_url')
+
+          echo "Pull Request created: $PR_URL"

--- a/.github/workflows/cd-cerner.yml
+++ b/.github/workflows/cd-cerner.yml
@@ -1,0 +1,140 @@
+name: CD - Cerner
+
+on:
+  workflow_dispatch:
+    inputs:
+      bal_central_environment:
+        description: Ballerina Central Environment
+        type: choice
+        options:
+        - STAGE
+        - DEV
+        - PROD
+        required: true
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    env:
+      JAVA_OPTS: -Xmx4G
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Ballerina Build Cerner
+        uses: ballerina-platform/ballerina-action@2201.6.0
+        with:
+          args:
+            pack
+        env:
+          WORKING_DIR: ./r4/cerner
+          JAVA_HOME: /usr/lib/jvm/default-jvm
+
+      - name: Push to Staging Cerner
+        if: github.event.inputs.bal_central_environment == 'STAGE'
+        uses: ballerina-platform/ballerina-action@2201.6.0
+        with:
+          args:
+            push
+        env:
+          WORKING_DIR: ./r4/cerner
+          JAVA_HOME: /usr/lib/jvm/default-jvm
+          BALLERINA_STAGE_CENTRAL: true
+          BALLERINA_CENTRAL_ACCESS_TOKEN: ${{ secrets.BALLERINA_CENTRAL_STAGE_ACCESS_TOKEN }}
+
+      - name: Push to Dev Cerner
+        if: github.event.inputs.bal_central_environment == 'DEV'
+        uses: ballerina-platform/ballerina-action@2201.6.0
+        with:
+          args:
+            push
+        env:
+          WORKING_DIR: ./r4/cerner
+          JAVA_HOME: /usr/lib/jvm/default-jvm
+          BALLERINA_DEV_CENTRAL: true
+          BALLERINA_CENTRAL_ACCESS_TOKEN: ${{ secrets.BALLERINA_CENTRAL_DEV_ACCESS_TOKEN }}      
+
+      - name: Push to Prod Cerner
+        if: github.event.inputs.bal_central_environment == 'PROD'
+        uses: ballerina-platform/ballerina-action@2201.6.0
+        with:
+          args:
+            push
+        env:
+          WORKING_DIR: ./r4/cerner
+          JAVA_HOME: /usr/lib/jvm/default-jvm
+          BALLERINA_CENTRAL_ACCESS_TOKEN: ${{ secrets.BALLERINA_CENTRAL_PROD_ACCESS_TOKEN }}
+
+      - name: Publish Release
+        if: github.event.inputs.bal_central_environment == 'PROD'
+        id: publish_release
+        run: |
+          # Get Branch Name
+          BRANCH_NAME=$(echo ${GITHUB_REF#refs/heads/})
+          echo "BRANCH_NAME=${BRANCH_NAME}" >> $GITHUB_OUTPUT
+          # Release name
+          RELEASE_NAME=${BRANCH_NAME#release-}
+          curl \
+            -s -X POST \
+            -H "Authorization: Bearer ${{ secrets.BALLERINA_BOT_TOKEN }}" \
+            -H "Accept: application/vnd.github.v3+json" \
+            -d '{
+              "tag_name": "'$RELEASE_NAME'",
+              "name": "'$RELEASE_NAME'",
+              "body": "[Automated] Creating tag:  '$RELEASE_NAME'.",
+              "draft": false,
+              "prerelease": false,
+              "target_commitish": "'$BRANCH_NAME'"
+            }' \
+            "https://api.github.com/repos/${{ github.repository }}/releases"
+
+      - name: Update version in Ballerina.toml
+        if: ${{ github.event.inputs.bal_central_environment == 'PROD' }}
+        id: increment_patch_version
+        run: |
+          CURRENT_VERSION=$(grep -Po -m 1 '(?<=version = ")[\d.]+' ./r4/cerner/Ballerina.toml)
+          IFS='.' read -ra VERSION_PARTS <<< "$CURRENT_VERSION"
+          PATCH_VERSION=$((VERSION_PARTS[2] + 1))
+          NEW_VERSION="${VERSION_PARTS[0]}.${VERSION_PARTS[1]}.$PATCH_VERSION-snapshot"
+          sed -i "0,/version = \"${CURRENT_VERSION}\"/s//version = \"${NEW_VERSION}\"/" ./r4/cerner/Ballerina.toml
+          echo "NEW_VERSION=${NEW_VERSION}" >> $GITHUB_OUTPUT
+          echo "CURRENT_VERSION=${CURRENT_VERSION}" >> $GITHUB_OUTPUT
+
+      - name: Ballerina Build after incrementing version
+        if: ${{ github.event.inputs.bal_central_environment == 'PROD' }}
+        uses: ballerina-platform/ballerina-action@2201.6.0
+        with:
+          args:
+            pack
+        env:
+          WORKING_DIR: ./r4/cerner
+          JAVA_HOME: /usr/lib/jvm/default-jvm
+
+      - name: Commit changes and make a PR
+        if: ${{ github.event.inputs.bal_central_environment == 'PROD' }}
+        run: |
+          # Commit changes
+          git config --global user.name ${{ secrets.BALLERINA_BOT_USERNAME }}
+          git config --global user.email ${{ secrets.BALLERINA_BOT_EMAIL }}
+          git add ./r4/cerner/Ballerina.toml
+          git add ./r4/cerner/Dependencies.toml
+          git commit -m "[Release cerner ${{ steps.increment_patch_version.outputs.CURRENT_VERSION }}] Prepare for next dev cycle"
+          git push origin ${{ steps.publish_release.outputs.BRANCH_NAME }}
+          
+          # Set the base and head branches
+          BASE_BRANCH="main"
+          HEAD_BRANCH="${{ steps.publish_release.outputs.BRANCH_NAME }}"
+          # Create the pull request using the GitHub REST API
+          RESPONSE=$(curl -s -X POST \
+            -H "Authorization: Bearer ${{ secrets.BALLERINA_BOT_TOKEN }}" \
+            -H "Accept: application/vnd.github.v3+json" \
+            -d '{
+              "title": "[Release cerner ${{ steps.increment_patch_version.outputs.CURRENT_VERSION }}] Prepare for next dev cycle",
+              "body": "",
+              "head": "'"$HEAD_BRANCH"'",
+              "base": "'"$BASE_BRANCH"'"
+            }' \
+            "https://api.github.com/repos/${{ github.repository }}/pulls")
+          # Extract the pull request URL from the response
+          PR_URL=$(echo "$RESPONSE" | jq -r '.html_url')
+
+          echo "Pull Request created: $PR_URL"

--- a/.github/workflows/cd-epic.yml
+++ b/.github/workflows/cd-epic.yml
@@ -1,0 +1,140 @@
+name: CD - Epic
+
+on:
+  workflow_dispatch:
+    inputs:
+      bal_central_environment:
+        description: Ballerina Central Environment
+        type: choice
+        options:
+        - STAGE
+        - DEV
+        - PROD
+        required: true
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    env:
+      JAVA_OPTS: -Xmx4G
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Ballerina Build Epic
+        uses: ballerina-platform/ballerina-action@2201.6.0
+        with:
+          args:
+            pack
+        env:
+          WORKING_DIR: ./r4/epic
+          JAVA_HOME: /usr/lib/jvm/default-jvm
+
+      - name: Push to Staging Epic
+        if: github.event.inputs.bal_central_environment == 'STAGE'
+        uses: ballerina-platform/ballerina-action@2201.6.0
+        with:
+          args:
+            push
+        env:
+          WORKING_DIR: ./r4/epic
+          JAVA_HOME: /usr/lib/jvm/default-jvm
+          BALLERINA_STAGE_CENTRAL: true
+          BALLERINA_CENTRAL_ACCESS_TOKEN: ${{ secrets.BALLERINA_CENTRAL_STAGE_ACCESS_TOKEN }}
+
+      - name: Push to Dev Epic
+        if: github.event.inputs.bal_central_environment == 'DEV'
+        uses: ballerina-platform/ballerina-action@2201.6.0
+        with:
+          args:
+            push
+        env:
+          WORKING_DIR: ./r4/epic
+          JAVA_HOME: /usr/lib/jvm/default-jvm
+          BALLERINA_DEV_CENTRAL: true
+          BALLERINA_CENTRAL_ACCESS_TOKEN: ${{ secrets.BALLERINA_CENTRAL_DEV_ACCESS_TOKEN }}      
+
+      - name: Push to Prod Epic
+        if: github.event.inputs.bal_central_environment == 'PROD'
+        uses: ballerina-platform/ballerina-action@2201.6.0
+        with:
+          args:
+            push
+        env:
+          WORKING_DIR: ./r4/epic
+          JAVA_HOME: /usr/lib/jvm/default-jvm
+          BALLERINA_CENTRAL_ACCESS_TOKEN: ${{ secrets.BALLERINA_CENTRAL_PROD_ACCESS_TOKEN }}
+
+      - name: Publish Release
+        if: github.event.inputs.bal_central_environment == 'PROD'
+        id: publish_release
+        run: |
+          # Get Branch Name
+          BRANCH_NAME=$(echo ${GITHUB_REF#refs/heads/})
+          echo "BRANCH_NAME=${BRANCH_NAME}" >> $GITHUB_OUTPUT
+          # Release name
+          RELEASE_NAME=${BRANCH_NAME#release-}
+          curl \
+            -s -X POST \
+            -H "Authorization: Bearer ${{ secrets.BALLERINA_BOT_TOKEN }}" \
+            -H "Accept: application/vnd.github.v3+json" \
+            -d '{
+              "tag_name": "'$RELEASE_NAME'",
+              "name": "'$RELEASE_NAME'",
+              "body": "[Automated] Creating tag:  '$RELEASE_NAME'.",
+              "draft": false,
+              "prerelease": false,
+              "target_commitish": "'$BRANCH_NAME'"
+            }' \
+            "https://api.github.com/repos/${{ github.repository }}/releases"
+
+      - name: Update version in Ballerina.toml
+        if: ${{ github.event.inputs.bal_central_environment == 'PROD' }}
+        id: increment_patch_version
+        run: |
+          CURRENT_VERSION=$(grep -Po -m 1 '(?<=version = ")[\d.]+' ./r4/epic/Ballerina.toml)
+          IFS='.' read -ra VERSION_PARTS <<< "$CURRENT_VERSION"
+          PATCH_VERSION=$((VERSION_PARTS[2] + 1))
+          NEW_VERSION="${VERSION_PARTS[0]}.${VERSION_PARTS[1]}.$PATCH_VERSION-snapshot"
+          sed -i "0,/version = \"${CURRENT_VERSION}\"/s//version = \"${NEW_VERSION}\"/" ./r4/epic/Ballerina.toml
+          echo "NEW_VERSION=${NEW_VERSION}" >> $GITHUB_OUTPUT
+          echo "CURRENT_VERSION=${CURRENT_VERSION}" >> $GITHUB_OUTPUT
+
+      - name: Ballerina Build after incrementing version
+        if: ${{ github.event.inputs.bal_central_environment == 'PROD' }}
+        uses: ballerina-platform/ballerina-action@2201.6.0
+        with:
+          args:
+            pack
+        env:
+          WORKING_DIR: ./r4/epic
+          JAVA_HOME: /usr/lib/jvm/default-jvm
+
+      - name: Commit changes and make a PR
+        if: ${{ github.event.inputs.bal_central_environment == 'PROD' }}
+        run: |
+          # Commit changes
+          git config --global user.name ${{ secrets.BALLERINA_BOT_USERNAME }}
+          git config --global user.email ${{ secrets.BALLERINA_BOT_EMAIL }}
+          git add ./r4/epic/Ballerina.toml
+          git add ./r4/epic/Dependencies.toml
+          git commit -m "[Release epic ${{ steps.increment_patch_version.outputs.CURRENT_VERSION }}] Prepare for next dev cycle"
+          git push origin ${{ steps.publish_release.outputs.BRANCH_NAME }}
+          
+          # Set the base and head branches
+          BASE_BRANCH="main"
+          HEAD_BRANCH="${{ steps.publish_release.outputs.BRANCH_NAME }}"
+          # Create the pull request using the GitHub REST API
+          RESPONSE=$(curl -s -X POST \
+            -H "Authorization: Bearer ${{ secrets.BALLERINA_BOT_TOKEN }}" \
+            -H "Accept: application/vnd.github.v3+json" \
+            -d '{
+              "title": "[Release epic ${{ steps.increment_patch_version.outputs.CURRENT_VERSION }}] Prepare for next dev cycle",
+              "body": "",
+              "head": "'"$HEAD_BRANCH"'",
+              "base": "'"$BASE_BRANCH"'"
+            }' \
+            "https://api.github.com/repos/${{ github.repository }}/pulls")
+          # Extract the pull request URL from the response
+          PR_URL=$(echo "$RESPONSE" | jq -r '.html_url')
+
+          echo "Pull Request created: $PR_URL"

--- a/.github/workflows/cd-metadata.yml
+++ b/.github/workflows/cd-metadata.yml
@@ -1,0 +1,140 @@
+name: CD - Metadata
+
+on:
+  workflow_dispatch:
+    inputs:
+      bal_central_environment:
+        description: Ballerina Central Environment
+        type: choice
+        options:
+        - STAGE
+        - DEV
+        - PROD
+        required: true
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    env:
+      JAVA_OPTS: -Xmx4G
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Ballerina Build Metadata
+        uses: ballerina-platform/ballerina-action@2201.6.0
+        with:
+          args:
+            pack
+        env:
+          WORKING_DIR: ./r4/metadata
+          JAVA_HOME: /usr/lib/jvm/default-jvm
+
+      - name: Push to Staging Metadata
+        if: github.event.inputs.bal_central_environment == 'STAGE'
+        uses: ballerina-platform/ballerina-action@2201.6.0
+        with:
+          args:
+            push
+        env:
+          WORKING_DIR: ./r4/metadata
+          JAVA_HOME: /usr/lib/jvm/default-jvm
+          BALLERINA_STAGE_CENTRAL: true
+          BALLERINA_CENTRAL_ACCESS_TOKEN: ${{ secrets.BALLERINA_CENTRAL_STAGE_ACCESS_TOKEN }}
+
+      - name: Push to Dev Metadata
+        if: github.event.inputs.bal_central_environment == 'DEV'
+        uses: ballerina-platform/ballerina-action@2201.6.0
+        with:
+          args:
+            push
+        env:
+          WORKING_DIR: ./r4/metadata
+          JAVA_HOME: /usr/lib/jvm/default-jvm
+          BALLERINA_DEV_CENTRAL: true
+          BALLERINA_CENTRAL_ACCESS_TOKEN: ${{ secrets.BALLERINA_CENTRAL_DEV_ACCESS_TOKEN }}      
+
+      - name: Push to Prod Metadata
+        if: github.event.inputs.bal_central_environment == 'PROD'
+        uses: ballerina-platform/ballerina-action@2201.6.0
+        with:
+          args:
+            push
+        env:
+          WORKING_DIR: ./r4/metadata
+          JAVA_HOME: /usr/lib/jvm/default-jvm
+          BALLERINA_CENTRAL_ACCESS_TOKEN: ${{ secrets.BALLERINA_CENTRAL_PROD_ACCESS_TOKEN }}
+
+      - name: Publish Release
+        if: github.event.inputs.bal_central_environment == 'PROD'
+        id: publish_release
+        run: |
+          # Get Branch Name
+          BRANCH_NAME=$(echo ${GITHUB_REF#refs/heads/})
+          echo "BRANCH_NAME=${BRANCH_NAME}" >> $GITHUB_OUTPUT
+          # Release name
+          RELEASE_NAME=${BRANCH_NAME#release-}
+          curl \
+            -s -X POST \
+            -H "Authorization: Bearer ${{ secrets.BALLERINA_BOT_TOKEN }}" \
+            -H "Accept: application/vnd.github.v3+json" \
+            -d '{
+              "tag_name": "'$RELEASE_NAME'",
+              "name": "'$RELEASE_NAME'",
+              "body": "[Automated] Creating tag:  '$RELEASE_NAME'.",
+              "draft": false,
+              "prerelease": false,
+              "target_commitish": "'$BRANCH_NAME'"
+            }' \
+            "https://api.github.com/repos/${{ github.repository }}/releases"
+
+      - name: Update version in Ballerina.toml
+        if: ${{ github.event.inputs.bal_central_environment == 'PROD' }}
+        id: increment_patch_version
+        run: |
+          CURRENT_VERSION=$(grep -Po -m 1 '(?<=version = ")[\d.]+' ./r4/metadata/Ballerina.toml)
+          IFS='.' read -ra VERSION_PARTS <<< "$CURRENT_VERSION"
+          PATCH_VERSION=$((VERSION_PARTS[2] + 1))
+          NEW_VERSION="${VERSION_PARTS[0]}.${VERSION_PARTS[1]}.$PATCH_VERSION-snapshot"
+          sed -i "0,/version = \"${CURRENT_VERSION}\"/s//version = \"${NEW_VERSION}\"/" ./r4/metadata/Ballerina.toml
+          echo "NEW_VERSION=${NEW_VERSION}" >> $GITHUB_OUTPUT
+          echo "CURRENT_VERSION=${CURRENT_VERSION}" >> $GITHUB_OUTPUT
+
+      - name: Ballerina Build after incrementing version
+        if: ${{ github.event.inputs.bal_central_environment == 'PROD' }}
+        uses: ballerina-platform/ballerina-action@2201.6.0
+        with:
+          args:
+            pack
+        env:
+          WORKING_DIR: ./r4/metadata
+          JAVA_HOME: /usr/lib/jvm/default-jvm
+
+      - name: Commit changes and make a PR
+        if: ${{ github.event.inputs.bal_central_environment == 'PROD' }}
+        run: |
+          # Commit changes
+          git config --global user.name ${{ secrets.BALLERINA_BOT_USERNAME }}
+          git config --global user.email ${{ secrets.BALLERINA_BOT_EMAIL }}
+          git add ./r4/metadata/Ballerina.toml
+          git add ./r4/metadata/Dependencies.toml
+          git commit -m "[Release metadata ${{ steps.increment_patch_version.outputs.CURRENT_VERSION }}] Prepare for next dev cycle"
+          git push origin ${{ steps.publish_release.outputs.BRANCH_NAME }}
+          
+          # Set the base and head branches
+          BASE_BRANCH="main"
+          HEAD_BRANCH="${{ steps.publish_release.outputs.BRANCH_NAME }}"
+          # Create the pull request using the GitHub REST API
+          RESPONSE=$(curl -s -X POST \
+            -H "Authorization: Bearer ${{ secrets.BALLERINA_BOT_TOKEN }}" \
+            -H "Accept: application/vnd.github.v3+json" \
+            -d '{
+              "title": "[Release metadata ${{ steps.increment_patch_version.outputs.CURRENT_VERSION }}] Prepare for next dev cycle",
+              "body": "",
+              "head": "'"$HEAD_BRANCH"'",
+              "base": "'"$BASE_BRANCH"'"
+            }' \
+            "https://api.github.com/repos/${{ github.repository }}/pulls")
+          # Extract the pull request URL from the response
+          PR_URL=$(echo "$RESPONSE" | jq -r '.html_url')
+
+          echo "Pull Request created: $PR_URL"

--- a/.github/workflows/cd-repositorysync.yml
+++ b/.github/workflows/cd-repositorysync.yml
@@ -1,0 +1,140 @@
+name: CD - Repository Sync
+
+on:
+  workflow_dispatch:
+    inputs:
+      bal_central_environment:
+        description: Ballerina Central Environment
+        type: choice
+        options:
+        - STAGE
+        - DEV
+        - PROD
+        required: true
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    env:
+      JAVA_OPTS: -Xmx4G
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Ballerina Build Repository Sync
+        uses: ballerina-platform/ballerina-action@2201.6.0
+        with:
+          args:
+            pack
+        env:
+          WORKING_DIR: ./r4/repository-sync
+          JAVA_HOME: /usr/lib/jvm/default-jvm
+
+      - name: Push to Staging Repository Sync
+        if: github.event.inputs.bal_central_environment == 'STAGE'
+        uses: ballerina-platform/ballerina-action@2201.6.0
+        with:
+          args:
+            push
+        env:
+          WORKING_DIR: ./r4/repository-sync
+          JAVA_HOME: /usr/lib/jvm/default-jvm
+          BALLERINA_STAGE_CENTRAL: true
+          BALLERINA_CENTRAL_ACCESS_TOKEN: ${{ secrets.BALLERINA_CENTRAL_STAGE_ACCESS_TOKEN }}
+
+      - name: Push to Dev Repository Sync
+        if: github.event.inputs.bal_central_environment == 'DEV'
+        uses: ballerina-platform/ballerina-action@2201.6.0
+        with:
+          args:
+            push
+        env:
+          WORKING_DIR: ./r4/repository-sync
+          JAVA_HOME: /usr/lib/jvm/default-jvm
+          BALLERINA_DEV_CENTRAL: true
+          BALLERINA_CENTRAL_ACCESS_TOKEN: ${{ secrets.BALLERINA_CENTRAL_DEV_ACCESS_TOKEN }}      
+
+      - name: Push to Prod Repository Sync
+        if: github.event.inputs.bal_central_environment == 'PROD'
+        uses: ballerina-platform/ballerina-action@2201.6.0
+        with:
+          args:
+            push
+        env:
+          WORKING_DIR: ./r4/repository-sync
+          JAVA_HOME: /usr/lib/jvm/default-jvm
+          BALLERINA_CENTRAL_ACCESS_TOKEN: ${{ secrets.BALLERINA_CENTRAL_PROD_ACCESS_TOKEN }}
+
+      - name: Publish Release
+        if: github.event.inputs.bal_central_environment == 'PROD'
+        id: publish_release
+        run: |
+          # Get Branch Name
+          BRANCH_NAME=$(echo ${GITHUB_REF#refs/heads/})
+          echo "BRANCH_NAME=${BRANCH_NAME}" >> $GITHUB_OUTPUT
+          # Release name
+          RELEASE_NAME=${BRANCH_NAME#release-}
+          curl \
+            -s -X POST \
+            -H "Authorization: Bearer ${{ secrets.BALLERINA_BOT_TOKEN }}" \
+            -H "Accept: application/vnd.github.v3+json" \
+            -d '{
+              "tag_name": "'$RELEASE_NAME'",
+              "name": "'$RELEASE_NAME'",
+              "body": "[Automated] Creating tag:  '$RELEASE_NAME'.",
+              "draft": false,
+              "prerelease": false,
+              "target_commitish": "'$BRANCH_NAME'"
+            }' \
+            "https://api.github.com/repos/${{ github.repository }}/releases"
+
+      - name: Update version in Ballerina.toml
+        if: ${{ github.event.inputs.bal_central_environment == 'PROD' }}
+        id: increment_patch_version
+        run: |
+          CURRENT_VERSION=$(grep -Po -m 1 '(?<=version = ")[\d.]+' ./r4/repository-sync/Ballerina.toml)
+          IFS='.' read -ra VERSION_PARTS <<< "$CURRENT_VERSION"
+          PATCH_VERSION=$((VERSION_PARTS[2] + 1))
+          NEW_VERSION="${VERSION_PARTS[0]}.${VERSION_PARTS[1]}.$PATCH_VERSION-snapshot"
+          sed -i "0,/version = \"${CURRENT_VERSION}\"/s//version = \"${NEW_VERSION}\"/" ./r4/repository-sync/Ballerina.toml
+          echo "NEW_VERSION=${NEW_VERSION}" >> $GITHUB_OUTPUT
+          echo "CURRENT_VERSION=${CURRENT_VERSION}" >> $GITHUB_OUTPUT
+
+      - name: Ballerina Build after incrementing version
+        if: ${{ github.event.inputs.bal_central_environment == 'PROD' }}
+        uses: ballerina-platform/ballerina-action@2201.6.0
+        with:
+          args:
+            pack
+        env:
+          WORKING_DIR: ./r4/repository-sync
+          JAVA_HOME: /usr/lib/jvm/default-jvm
+
+      - name: Commit changes and make a PR
+        if: ${{ github.event.inputs.bal_central_environment == 'PROD' }}
+        run: |
+          # Commit changes
+          git config --global user.name ${{ secrets.BALLERINA_BOT_USERNAME }}
+          git config --global user.email ${{ secrets.BALLERINA_BOT_EMAIL }}
+          git add ./r4/repository-sync/Ballerina.toml
+          git add ./r4/repository-sync/Dependencies.toml
+          git commit -m "[Release repository sync ${{ steps.increment_patch_version.outputs.CURRENT_VERSION }}] Prepare for next dev cycle"
+          git push origin ${{ steps.publish_release.outputs.BRANCH_NAME }}
+          
+          # Set the base and head branches
+          BASE_BRANCH="main"
+          HEAD_BRANCH="${{ steps.publish_release.outputs.BRANCH_NAME }}"
+          # Create the pull request using the GitHub REST API
+          RESPONSE=$(curl -s -X POST \
+            -H "Authorization: Bearer ${{ secrets.BALLERINA_BOT_TOKEN }}" \
+            -H "Accept: application/vnd.github.v3+json" \
+            -d '{
+              "title": "[Release repository sync ${{ steps.increment_patch_version.outputs.CURRENT_VERSION }}] Prepare for next dev cycle",
+              "body": "",
+              "head": "'"$HEAD_BRANCH"'",
+              "base": "'"$BASE_BRANCH"'"
+            }' \
+            "https://api.github.com/repos/${{ github.repository }}/pulls")
+          # Extract the pull request URL from the response
+          PR_URL=$(echo "$RESPONSE" | jq -r '.html_url')
+
+          echo "Pull Request created: $PR_URL"

--- a/.github/workflows/cd-resourceapis-diagnosticReport.yml
+++ b/.github/workflows/cd-resourceapis-diagnosticReport.yml
@@ -1,0 +1,140 @@
+name: CD - resourceapis Diagnostic Report
+
+on:
+  workflow_dispatch:
+    inputs:
+      bal_central_environment:
+        description: Ballerina Central Environment
+        type: choice
+        options:
+        - STAGE
+        - DEV
+        - PROD
+        required: true
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    env:
+      JAVA_OPTS: -Xmx4G
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Ballerina Build Diagnostic Report
+        uses: ballerina-platform/ballerina-action@2201.6.0
+        with:
+          args:
+            pack
+        env:
+          WORKING_DIR: ./r4/resource-apis/diagnosticReport
+          JAVA_HOME: /usr/lib/jvm/default-jvm
+
+      - name: Push to Staging Diagnostic Report
+        if: github.event.inputs.bal_central_environment == 'STAGE'
+        uses: ballerina-platform/ballerina-action@2201.6.0
+        with:
+          args:
+            push
+        env:
+          WORKING_DIR: ./r4/resource-apis/diagnosticReport
+          JAVA_HOME: /usr/lib/jvm/default-jvm
+          BALLERINA_STAGE_CENTRAL: true
+          BALLERINA_CENTRAL_ACCESS_TOKEN: ${{ secrets.BALLERINA_CENTRAL_STAGE_ACCESS_TOKEN }}
+
+      - name: Push to Dev Diagnostic Report
+        if: github.event.inputs.bal_central_environment == 'DEV'
+        uses: ballerina-platform/ballerina-action@2201.6.0
+        with:
+          args:
+            push
+        env:
+          WORKING_DIR: ./r4/resource-apis/diagnosticReport
+          JAVA_HOME: /usr/lib/jvm/default-jvm
+          BALLERINA_DEV_CENTRAL: true
+          BALLERINA_CENTRAL_ACCESS_TOKEN: ${{ secrets.BALLERINA_CENTRAL_DEV_ACCESS_TOKEN }}      
+
+      - name: Push to Prod Diagnostic Report
+        if: github.event.inputs.bal_central_environment == 'PROD'
+        uses: ballerina-platform/ballerina-action@2201.6.0
+        with:
+          args:
+            push
+        env:
+          WORKING_DIR: ./r4/resource-apis/diagnosticReport
+          JAVA_HOME: /usr/lib/jvm/default-jvm
+          BALLERINA_CENTRAL_ACCESS_TOKEN: ${{ secrets.BALLERINA_CENTRAL_PROD_ACCESS_TOKEN }}
+
+      - name: Publish Release
+        if: github.event.inputs.bal_central_environment == 'PROD'
+        id: publish_release
+        run: |
+          # Get Branch Name
+          BRANCH_NAME=$(echo ${GITHUB_REF#refs/heads/})
+          echo "BRANCH_NAME=${BRANCH_NAME}" >> $GITHUB_OUTPUT
+          # Release name
+          RELEASE_NAME=${BRANCH_NAME#release-}
+          curl \
+            -s -X POST \
+            -H "Authorization: Bearer ${{ secrets.BALLERINA_BOT_TOKEN }}" \
+            -H "Accept: application/vnd.github.v3+json" \
+            -d '{
+              "tag_name": "'$RELEASE_NAME'",
+              "name": "'$RELEASE_NAME'",
+              "body": "[Automated] Creating tag:  '$RELEASE_NAME'.",
+              "draft": false,
+              "prerelease": false,
+              "target_commitish": "'$BRANCH_NAME'"
+            }' \
+            "https://api.github.com/repos/${{ github.repository }}/releases"
+
+      - name: Update version in Ballerina.toml
+        if: ${{ github.event.inputs.bal_central_environment == 'PROD' }}
+        id: increment_patch_version
+        run: |
+          CURRENT_VERSION=$(grep -Po -m 1 '(?<=version = ")[\d.]+' ./r4/resource-apis/diagnosticReport/Ballerina.toml)
+          IFS='.' read -ra VERSION_PARTS <<< "$CURRENT_VERSION"
+          PATCH_VERSION=$((VERSION_PARTS[2] + 1))
+          NEW_VERSION="${VERSION_PARTS[0]}.${VERSION_PARTS[1]}.$PATCH_VERSION-snapshot"
+          sed -i "0,/version = \"${CURRENT_VERSION}\"/s//version = \"${NEW_VERSION}\"/" ./r4/resource-apis/diagnosticReport/Ballerina.toml
+          echo "NEW_VERSION=${NEW_VERSION}" >> $GITHUB_OUTPUT
+          echo "CURRENT_VERSION=${CURRENT_VERSION}" >> $GITHUB_OUTPUT
+
+      - name: Ballerina Build after incrementing version
+        if: ${{ github.event.inputs.bal_central_environment == 'PROD' }}
+        uses: ballerina-platform/ballerina-action@2201.6.0
+        with:
+          args:
+            pack
+        env:
+          WORKING_DIR: ./r4/resource-apis/diagnosticReport
+          JAVA_HOME: /usr/lib/jvm/default-jvm
+
+      - name: Commit changes and make a PR
+        if: ${{ github.event.inputs.bal_central_environment == 'PROD' }}
+        run: |
+          # Commit changes
+          git config --global user.name ${{ secrets.BALLERINA_BOT_USERNAME }}
+          git config --global user.email ${{ secrets.BALLERINA_BOT_EMAIL }}
+          git add ./r4/resource-apis/diagnosticReport/Ballerina.toml
+          git add ./r4/resource-apis/diagnosticReport/Dependencies.toml
+          git commit -m "[Release resourceapis diagnostic report ${{ steps.increment_patch_version.outputs.CURRENT_VERSION }}] Prepare for next dev cycle"
+          git push origin ${{ steps.publish_release.outputs.BRANCH_NAME }}
+          
+          # Set the base and head branches
+          BASE_BRANCH="main"
+          HEAD_BRANCH="${{ steps.publish_release.outputs.BRANCH_NAME }}"
+          # Create the pull request using the GitHub REST API
+          RESPONSE=$(curl -s -X POST \
+            -H "Authorization: Bearer ${{ secrets.BALLERINA_BOT_TOKEN }}" \
+            -H "Accept: application/vnd.github.v3+json" \
+            -d '{
+              "title": "[Release resourceapis diagnostic report ${{ steps.increment_patch_version.outputs.CURRENT_VERSION }}] Prepare for next dev cycle",
+              "body": "",
+              "head": "'"$HEAD_BRANCH"'",
+              "base": "'"$BASE_BRANCH"'"
+            }' \
+            "https://api.github.com/repos/${{ github.repository }}/pulls")
+          # Extract the pull request URL from the response
+          PR_URL=$(echo "$RESPONSE" | jq -r '.html_url')
+
+          echo "Pull Request created: $PR_URL"

--- a/.github/workflows/cd-resourceapis-encounter.yml
+++ b/.github/workflows/cd-resourceapis-encounter.yml
@@ -1,0 +1,140 @@
+name: CD - resourceapis Encounter
+
+on:
+  workflow_dispatch:
+    inputs:
+      bal_central_environment:
+        description: Ballerina Central Environment
+        type: choice
+        options:
+        - STAGE
+        - DEV
+        - PROD
+        required: true
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    env:
+      JAVA_OPTS: -Xmx4G
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Ballerina Build Encounter
+        uses: ballerina-platform/ballerina-action@2201.6.0
+        with:
+          args:
+            pack
+        env:
+          WORKING_DIR: ./r4/resource-apis/encounter
+          JAVA_HOME: /usr/lib/jvm/default-jvm
+
+      - name: Push to Staging Encounter
+        if: github.event.inputs.bal_central_environment == 'STAGE'
+        uses: ballerina-platform/ballerina-action@2201.6.0
+        with:
+          args:
+            push
+        env:
+          WORKING_DIR: ./r4/resource-apis/encounter
+          JAVA_HOME: /usr/lib/jvm/default-jvm
+          BALLERINA_STAGE_CENTRAL: true
+          BALLERINA_CENTRAL_ACCESS_TOKEN: ${{ secrets.BALLERINA_CENTRAL_STAGE_ACCESS_TOKEN }}
+
+      - name: Push to Dev Encounter
+        if: github.event.inputs.bal_central_environment == 'DEV'
+        uses: ballerina-platform/ballerina-action@2201.6.0
+        with:
+          args:
+            push
+        env:
+          WORKING_DIR: ./r4/resource-apis/encounter
+          JAVA_HOME: /usr/lib/jvm/default-jvm
+          BALLERINA_DEV_CENTRAL: true
+          BALLERINA_CENTRAL_ACCESS_TOKEN: ${{ secrets.BALLERINA_CENTRAL_DEV_ACCESS_TOKEN }}      
+
+      - name: Push to Prod Encounter
+        if: github.event.inputs.bal_central_environment == 'PROD'
+        uses: ballerina-platform/ballerina-action@2201.6.0
+        with:
+          args:
+            push
+        env:
+          WORKING_DIR: ./r4/resource-apis/encounter
+          JAVA_HOME: /usr/lib/jvm/default-jvm
+          BALLERINA_CENTRAL_ACCESS_TOKEN: ${{ secrets.BALLERINA_CENTRAL_PROD_ACCESS_TOKEN }}
+
+      - name: Publish Release
+        if: github.event.inputs.bal_central_environment == 'PROD'
+        id: publish_release
+        run: |
+          # Get Branch Name
+          BRANCH_NAME=$(echo ${GITHUB_REF#refs/heads/})
+          echo "BRANCH_NAME=${BRANCH_NAME}" >> $GITHUB_OUTPUT
+          # Release name
+          RELEASE_NAME=${BRANCH_NAME#release-}
+          curl \
+            -s -X POST \
+            -H "Authorization: Bearer ${{ secrets.BALLERINA_BOT_TOKEN }}" \
+            -H "Accept: application/vnd.github.v3+json" \
+            -d '{
+              "tag_name": "'$RELEASE_NAME'",
+              "name": "'$RELEASE_NAME'",
+              "body": "[Automated] Creating tag:  '$RELEASE_NAME'.",
+              "draft": false,
+              "prerelease": false,
+              "target_commitish": "'$BRANCH_NAME'"
+            }' \
+            "https://api.github.com/repos/${{ github.repository }}/releases"
+
+      - name: Update version in Ballerina.toml
+        if: ${{ github.event.inputs.bal_central_environment == 'PROD' }}
+        id: increment_patch_version
+        run: |
+          CURRENT_VERSION=$(grep -Po -m 1 '(?<=version = ")[\d.]+' ./r4/resource-apis/encounter/Ballerina.toml)
+          IFS='.' read -ra VERSION_PARTS <<< "$CURRENT_VERSION"
+          PATCH_VERSION=$((VERSION_PARTS[2] + 1))
+          NEW_VERSION="${VERSION_PARTS[0]}.${VERSION_PARTS[1]}.$PATCH_VERSION-snapshot"
+          sed -i "0,/version = \"${CURRENT_VERSION}\"/s//version = \"${NEW_VERSION}\"/" ./r4/resource-apis/encounter/Ballerina.toml
+          echo "NEW_VERSION=${NEW_VERSION}" >> $GITHUB_OUTPUT
+          echo "CURRENT_VERSION=${CURRENT_VERSION}" >> $GITHUB_OUTPUT
+
+      - name: Ballerina Build after incrementing version
+        if: ${{ github.event.inputs.bal_central_environment == 'PROD' }}
+        uses: ballerina-platform/ballerina-action@2201.6.0
+        with:
+          args:
+            pack
+        env:
+          WORKING_DIR: ./r4/resource-apis/encounter
+          JAVA_HOME: /usr/lib/jvm/default-jvm
+
+      - name: Commit changes and make a PR
+        if: ${{ github.event.inputs.bal_central_environment == 'PROD' }}
+        run: |
+          # Commit changes
+          git config --global user.name ${{ secrets.BALLERINA_BOT_USERNAME }}
+          git config --global user.email ${{ secrets.BALLERINA_BOT_EMAIL }}
+          git add ./r4/resource-apis/encounter/Ballerina.toml
+          git add ./r4/resource-apis/encounter/Dependencies.toml
+          git commit -m "[Release resourceapis encounter ${{ steps.increment_patch_version.outputs.CURRENT_VERSION }}] Prepare for next dev cycle"
+          git push origin ${{ steps.publish_release.outputs.BRANCH_NAME }}
+          
+          # Set the base and head branches
+          BASE_BRANCH="main"
+          HEAD_BRANCH="${{ steps.publish_release.outputs.BRANCH_NAME }}"
+          # Create the pull request using the GitHub REST API
+          RESPONSE=$(curl -s -X POST \
+            -H "Authorization: Bearer ${{ secrets.BALLERINA_BOT_TOKEN }}" \
+            -H "Accept: application/vnd.github.v3+json" \
+            -d '{
+              "title": "[Release resourceapis encounter ${{ steps.increment_patch_version.outputs.CURRENT_VERSION }}] Prepare for next dev cycle",
+              "body": "",
+              "head": "'"$HEAD_BRANCH"'",
+              "base": "'"$BASE_BRANCH"'"
+            }' \
+            "https://api.github.com/repos/${{ github.repository }}/pulls")
+          # Extract the pull request URL from the response
+          PR_URL=$(echo "$RESPONSE" | jq -r '.html_url')
+
+          echo "Pull Request created: $PR_URL"

--- a/.github/workflows/cd-resourceapis-observation.yml
+++ b/.github/workflows/cd-resourceapis-observation.yml
@@ -1,0 +1,139 @@
+name: CD - resourceapis Observation
+
+on:
+  workflow_dispatch:
+    inputs:
+      bal_central_environment:
+        description: Ballerina Central Environment
+        type: choice
+        options:
+        - STAGE
+        - DEV
+        - PROD
+        required: true
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    env:
+      JAVA_OPTS: -Xmx4G
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Ballerina Build Observation
+        uses: ballerina-platform/ballerina-action@2201.6.0
+        with:
+          args:
+            pack
+        env:
+          WORKING_DIR: ./r4/resource-apis/observation
+          JAVA_HOME: /usr/lib/jvm/default-jvm
+
+      - name: Push to Staging Observation
+        if: github.event.inputs.bal_central_environment == 'STAGE'
+        uses: ballerina-platform/ballerina-action@2201.6.0
+        with:
+          args:
+            push
+        env:
+          WORKING_DIR: ./r4/resource-apis/observation
+          JAVA_HOME: /usr/lib/jvm/default-jvm
+          BALLERINA_STAGE_CENTRAL: true
+          BALLERINA_CENTRAL_ACCESS_TOKEN: ${{ secrets.BALLERINA_CENTRAL_STAGE_ACCESS_TOKEN }}
+
+      - name: Push to Dev Observation
+        if: github.event.inputs.bal_central_environment == 'DEV'
+        uses: ballerina-platform/ballerina-action@2201.6.0
+        with:
+          args:
+            push
+        env:
+          WORKING_DIR: ./r4/resource-apis/observation
+          JAVA_HOME: /usr/lib/jvm/default-jvm
+          BALLERINA_DEV_CENTRAL: true
+          BALLERINA_CENTRAL_ACCESS_TOKEN: ${{ secrets.BALLERINA_CENTRAL_DEV_ACCESS_TOKEN }}      
+
+      - name: Push to Prod Observation
+        if: github.event.inputs.bal_central_environment == 'PROD'
+        uses: ballerina-platform/ballerina-action@2201.6.0
+        with:
+          args:
+            push
+        env:
+          WORKING_DIR: ./r4/resource-apis/observation
+          JAVA_HOME: /usr/lib/jvm/default-jvm
+          BALLERINA_CENTRAL_ACCESS_TOKEN: ${{ secrets.BALLERINA_CENTRAL_PROD_ACCESS_TOKEN }}
+
+      - name: Publish Release
+        if: github.event.inputs.bal_central_environment == 'PROD'
+        id: publish_release
+        run: |
+          # Get Branch Name
+          BRANCH_NAME=$(echo ${GITHUB_REF#refs/heads/})
+          echo "BRANCH_NAME=${BRANCH_NAME}" >> $GITHUB_OUTPUT
+          # Release name
+          RELEASE_NAME=${BRANCH_NAME#release-}
+          curl \
+            -s -X POST \
+            -H "Authorization: Bearer ${{ secrets.BALLERINA_BOT_TOKEN }}" \
+            -H "Accept: application/vnd.github.v3+json" \
+            -d '{
+              "tag_name": "'$RELEASE_NAME'",
+              "name": "'$RELEASE_NAME'",
+              "body": "[Automated] Creating tag:  '$RELEASE_NAME'.",
+              "draft": false,
+              "prerelease": false,
+              "target_commitish": "'$BRANCH_NAME'"
+            }' \
+            "https://api.github.com/repos/${{ github.repository }}/releases"
+
+      - name: Update version in Ballerina.toml
+        if: ${{ github.event.inputs.bal_central_environment == 'PROD' }}
+        id: increment_patch_version
+        run: |
+          CURRENT_VERSION=$(grep -Po -m 1 '(?<=version = ")[\d.]+' ./r4/resource-apis/observation/Ballerina.toml)
+          IFS='.' read -ra VERSION_PARTS <<< "$CURRENT_VERSION"
+          PATCH_VERSION=$((VERSION_PARTS[2] + 1))
+          NEW_VERSION="${VERSION_PARTS[0]}.${VERSION_PARTS[1]}.$PATCH_VERSION-snapshot"
+          sed -i "0,/version = \"${CURRENT_VERSION}\"/s//version = \"${NEW_VERSION}\"/" ./r4/resource-apis/observation/Ballerina.toml
+          echo "NEW_VERSION=${NEW_VERSION}" >> $GITHUB_OUTPUT
+          echo "CURRENT_VERSION=${CURRENT_VERSION}" >> $GITHUB_OUTPUT
+
+      - name: Ballerina Build after incrementing version
+        if: ${{ github.event.inputs.bal_central_environment == 'PROD' }}
+        uses: ballerina-platform/ballerina-action@2201.6.0
+        with:
+          args:
+            pack
+        env:
+          WORKING_DIR: ./r4/resource-apis/observation
+          JAVA_HOME: /usr/lib/jvm/default-jvm
+
+      - name: Commit changes and make a PR
+        if: ${{ github.event.inputs.bal_central_environment == 'PROD' }}
+        run: |
+          # Commit changes
+          git config --global user.name ${{ secrets.BALLERINA_BOT_USERNAME }}
+          git config --global user.email ${{ secrets.BALLERINA_BOT_EMAIL }}
+          git add ./r4/resource-apis/observation/Ballerina.toml
+          git commit -m "[Release resourceapis observation ${{ steps.increment_patch_version.outputs.CURRENT_VERSION }}] Prepare for next dev cycle"
+          git push origin ${{ steps.publish_release.outputs.BRANCH_NAME }}
+          
+          # Set the base and head branches
+          BASE_BRANCH="main"
+          HEAD_BRANCH="${{ steps.publish_release.outputs.BRANCH_NAME }}"
+          # Create the pull request using the GitHub REST API
+          RESPONSE=$(curl -s -X POST \
+            -H "Authorization: Bearer ${{ secrets.BALLERINA_BOT_TOKEN }}" \
+            -H "Accept: application/vnd.github.v3+json" \
+            -d '{
+              "title": "[Release resourceapis observation ${{ steps.increment_patch_version.outputs.CURRENT_VERSION }}] Prepare for next dev cycle",
+              "body": "",
+              "head": "'"$HEAD_BRANCH"'",
+              "base": "'"$BASE_BRANCH"'"
+            }' \
+            "https://api.github.com/repos/${{ github.repository }}/pulls")
+          # Extract the pull request URL from the response
+          PR_URL=$(echo "$RESPONSE" | jq -r '.html_url')
+
+          echo "Pull Request created: $PR_URL"

--- a/.github/workflows/cd-resourceapis-organization.yml
+++ b/.github/workflows/cd-resourceapis-organization.yml
@@ -1,0 +1,140 @@
+name: CD - resourceapis Organization
+
+on:
+  workflow_dispatch:
+    inputs:
+      bal_central_environment:
+        description: Ballerina Central Environment
+        type: choice
+        options:
+        - STAGE
+        - DEV
+        - PROD
+        required: true
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    env:
+      JAVA_OPTS: -Xmx4G
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Ballerina Build Organization
+        uses: ballerina-platform/ballerina-action@2201.6.0
+        with:
+          args:
+            pack
+        env:
+          WORKING_DIR: ./r4/resource-apis/organization
+          JAVA_HOME: /usr/lib/jvm/default-jvm
+
+      - name: Push to Staging Organization
+        if: github.event.inputs.bal_central_environment == 'STAGE'
+        uses: ballerina-platform/ballerina-action@2201.6.0
+        with:
+          args:
+            push
+        env:
+          WORKING_DIR: ./r4/resource-apis/organization
+          JAVA_HOME: /usr/lib/jvm/default-jvm
+          BALLERINA_STAGE_CENTRAL: true
+          BALLERINA_CENTRAL_ACCESS_TOKEN: ${{ secrets.BALLERINA_CENTRAL_STAGE_ACCESS_TOKEN }}
+
+      - name: Push to Dev Organization
+        if: github.event.inputs.bal_central_environment == 'DEV'
+        uses: ballerina-platform/ballerina-action@2201.6.0
+        with:
+          args:
+            push
+        env:
+          WORKING_DIR: ./r4/resource-apis/organization
+          JAVA_HOME: /usr/lib/jvm/default-jvm
+          BALLERINA_DEV_CENTRAL: true
+          BALLERINA_CENTRAL_ACCESS_TOKEN: ${{ secrets.BALLERINA_CENTRAL_DEV_ACCESS_TOKEN }}      
+
+      - name: Push to Prod Organization
+        if: github.event.inputs.bal_central_environment == 'PROD'
+        uses: ballerina-platform/ballerina-action@2201.6.0
+        with:
+          args:
+            push
+        env:
+          WORKING_DIR: ./r4/resource-apis/organization
+          JAVA_HOME: /usr/lib/jvm/default-jvm
+          BALLERINA_CENTRAL_ACCESS_TOKEN: ${{ secrets.BALLERINA_CENTRAL_PROD_ACCESS_TOKEN }}
+
+      - name: Publish Release
+        if: github.event.inputs.bal_central_environment == 'PROD'
+        id: publish_release
+        run: |
+          # Get Branch Name
+          BRANCH_NAME=$(echo ${GITHUB_REF#refs/heads/})
+          echo "BRANCH_NAME=${BRANCH_NAME}" >> $GITHUB_OUTPUT
+          # Release name
+          RELEASE_NAME=${BRANCH_NAME#release-}
+          curl \
+            -s -X POST \
+            -H "Authorization: Bearer ${{ secrets.BALLERINA_BOT_TOKEN }}" \
+            -H "Accept: application/vnd.github.v3+json" \
+            -d '{
+              "tag_name": "'$RELEASE_NAME'",
+              "name": "'$RELEASE_NAME'",
+              "body": "[Automated] Creating tag:  '$RELEASE_NAME'.",
+              "draft": false,
+              "prerelease": false,
+              "target_commitish": "'$BRANCH_NAME'"
+            }' \
+            "https://api.github.com/repos/${{ github.repository }}/releases"
+
+      - name: Update version in Ballerina.toml
+        if: ${{ github.event.inputs.bal_central_environment == 'PROD' }}
+        id: increment_patch_version
+        run: |
+          CURRENT_VERSION=$(grep -Po -m 1 '(?<=version = ")[\d.]+' ./r4/resource-apis/organization/Ballerina.toml)
+          IFS='.' read -ra VERSION_PARTS <<< "$CURRENT_VERSION"
+          PATCH_VERSION=$((VERSION_PARTS[2] + 1))
+          NEW_VERSION="${VERSION_PARTS[0]}.${VERSION_PARTS[1]}.$PATCH_VERSION-snapshot"
+          sed -i "0,/version = \"${CURRENT_VERSION}\"/s//version = \"${NEW_VERSION}\"/" ./r4/resource-apis/organization/Ballerina.toml
+          echo "NEW_VERSION=${NEW_VERSION}" >> $GITHUB_OUTPUT
+          echo "CURRENT_VERSION=${CURRENT_VERSION}" >> $GITHUB_OUTPUT
+
+      - name: Ballerina Build after incrementing version
+        if: ${{ github.event.inputs.bal_central_environment == 'PROD' }}
+        uses: ballerina-platform/ballerina-action@2201.6.0
+        with:
+          args:
+            pack
+        env:
+          WORKING_DIR: ./r4/resource-apis/organization
+          JAVA_HOME: /usr/lib/jvm/default-jvm
+
+      - name: Commit changes and make a PR
+        if: ${{ github.event.inputs.bal_central_environment == 'PROD' }}
+        run: |
+          # Commit changes
+          git config --global user.name ${{ secrets.BALLERINA_BOT_USERNAME }}
+          git config --global user.email ${{ secrets.BALLERINA_BOT_EMAIL }}
+          git add ./r4/resource-apis/organization/Ballerina.toml
+          git add ./r4/resource-apis/organization/Dependencies.toml
+          git commit -m "[Release resourceapis organization ${{ steps.increment_patch_version.outputs.CURRENT_VERSION }}] Prepare for next dev cycle"
+          git push origin ${{ steps.publish_release.outputs.BRANCH_NAME }}
+          
+          # Set the base and head branches
+          BASE_BRANCH="main"
+          HEAD_BRANCH="${{ steps.publish_release.outputs.BRANCH_NAME }}"
+          # Create the pull request using the GitHub REST API
+          RESPONSE=$(curl -s -X POST \
+            -H "Authorization: Bearer ${{ secrets.BALLERINA_BOT_TOKEN }}" \
+            -H "Accept: application/vnd.github.v3+json" \
+            -d '{
+              "title": "[Release resourceapis organization ${{ steps.increment_patch_version.outputs.CURRENT_VERSION }}] Prepare for next dev cycle",
+              "body": "",
+              "head": "'"$HEAD_BRANCH"'",
+              "base": "'"$BASE_BRANCH"'"
+            }' \
+            "https://api.github.com/repos/${{ github.repository }}/pulls")
+          # Extract the pull request URL from the response
+          PR_URL=$(echo "$RESPONSE" | jq -r '.html_url')
+
+          echo "Pull Request created: $PR_URL"

--- a/.github/workflows/cd-resourceapis-patient.yml
+++ b/.github/workflows/cd-resourceapis-patient.yml
@@ -1,0 +1,140 @@
+name: CD - resourceapis Patient
+
+on:
+  workflow_dispatch:
+    inputs:
+      bal_central_environment:
+        description: Ballerina Central Environment
+        type: choice
+        options:
+        - STAGE
+        - DEV
+        - PROD
+        required: true
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    env:
+      JAVA_OPTS: -Xmx4G
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Ballerina Build Patient
+        uses: ballerina-platform/ballerina-action@2201.6.0
+        with:
+          args:
+            pack
+        env:
+          WORKING_DIR: ./r4/resource-apis/patient
+          JAVA_HOME: /usr/lib/jvm/default-jvm
+
+      - name: Push to Staging Patient
+        if: github.event.inputs.bal_central_environment == 'STAGE'
+        uses: ballerina-platform/ballerina-action@2201.6.0
+        with:
+          args:
+            push
+        env:
+          WORKING_DIR: ./r4/resource-apis/patient
+          JAVA_HOME: /usr/lib/jvm/default-jvm
+          BALLERINA_STAGE_CENTRAL: true
+          BALLERINA_CENTRAL_ACCESS_TOKEN: ${{ secrets.BALLERINA_CENTRAL_STAGE_ACCESS_TOKEN }}
+
+      - name: Push to Dev Patient
+        if: github.event.inputs.bal_central_environment == 'DEV'
+        uses: ballerina-platform/ballerina-action@2201.6.0
+        with:
+          args:
+            push
+        env:
+          WORKING_DIR: ./r4/resource-apis/patient
+          JAVA_HOME: /usr/lib/jvm/default-jvm
+          BALLERINA_DEV_CENTRAL: true
+          BALLERINA_CENTRAL_ACCESS_TOKEN: ${{ secrets.BALLERINA_CENTRAL_DEV_ACCESS_TOKEN }}      
+
+      - name: Push to Prod Patient
+        if: github.event.inputs.bal_central_environment == 'PROD'
+        uses: ballerina-platform/ballerina-action@2201.6.0
+        with:
+          args:
+            push
+        env:
+          WORKING_DIR: ./r4/resource-apis/patient
+          JAVA_HOME: /usr/lib/jvm/default-jvm
+          BALLERINA_CENTRAL_ACCESS_TOKEN: ${{ secrets.BALLERINA_CENTRAL_PROD_ACCESS_TOKEN }}
+
+      - name: Publish Release
+        if: github.event.inputs.bal_central_environment == 'PROD'
+        id: publish_release
+        run: |
+          # Get Branch Name
+          BRANCH_NAME=$(echo ${GITHUB_REF#refs/heads/})
+          echo "BRANCH_NAME=${BRANCH_NAME}" >> $GITHUB_OUTPUT
+          # Release name
+          RELEASE_NAME=${BRANCH_NAME#release-}
+          curl \
+            -s -X POST \
+            -H "Authorization: Bearer ${{ secrets.BALLERINA_BOT_TOKEN }}" \
+            -H "Accept: application/vnd.github.v3+json" \
+            -d '{
+              "tag_name": "'$RELEASE_NAME'",
+              "name": "'$RELEASE_NAME'",
+              "body": "[Automated] Creating tag:  '$RELEASE_NAME'.",
+              "draft": false,
+              "prerelease": false,
+              "target_commitish": "'$BRANCH_NAME'"
+            }' \
+            "https://api.github.com/repos/${{ github.repository }}/releases"
+
+      - name: Update version in Ballerina.toml
+        if: ${{ github.event.inputs.bal_central_environment == 'PROD' }}
+        id: increment_patch_version
+        run: |
+          CURRENT_VERSION=$(grep -Po -m 1 '(?<=version = ")[\d.]+' ./r4/resource-apis/patient/Ballerina.toml)
+          IFS='.' read -ra VERSION_PARTS <<< "$CURRENT_VERSION"
+          PATCH_VERSION=$((VERSION_PARTS[2] + 1))
+          NEW_VERSION="${VERSION_PARTS[0]}.${VERSION_PARTS[1]}.$PATCH_VERSION-snapshot"
+          sed -i "0,/version = \"${CURRENT_VERSION}\"/s//version = \"${NEW_VERSION}\"/" ./r4/resource-apis/patient/Ballerina.toml
+          echo "NEW_VERSION=${NEW_VERSION}" >> $GITHUB_OUTPUT
+          echo "CURRENT_VERSION=${CURRENT_VERSION}" >> $GITHUB_OUTPUT
+
+      - name: Ballerina Build after incrementing version
+        if: ${{ github.event.inputs.bal_central_environment == 'PROD' }}
+        uses: ballerina-platform/ballerina-action@2201.6.0
+        with:
+          args:
+            pack
+        env:
+          WORKING_DIR: ./r4/resource-apis/patient
+          JAVA_HOME: /usr/lib/jvm/default-jvm
+
+      - name: Commit changes and make a PR
+        if: ${{ github.event.inputs.bal_central_environment == 'PROD' }}
+        run: |
+          # Commit changes
+          git config --global user.name ${{ secrets.BALLERINA_BOT_USERNAME }}
+          git config --global user.email ${{ secrets.BALLERINA_BOT_EMAIL }}
+          git add ./r4/resource-apis/patient/Ballerina.toml
+          git add ./r4/resource-apis/patient/Dependencies.toml
+          git commit -m "[Release resourceapis patient ${{ steps.increment_patch_version.outputs.CURRENT_VERSION }}] Prepare for next dev cycle"
+          git push origin ${{ steps.publish_release.outputs.BRANCH_NAME }}
+          
+          # Set the base and head branches
+          BASE_BRANCH="main"
+          HEAD_BRANCH="${{ steps.publish_release.outputs.BRANCH_NAME }}"
+          # Create the pull request using the GitHub REST API
+          RESPONSE=$(curl -s -X POST \
+            -H "Authorization: Bearer ${{ secrets.BALLERINA_BOT_TOKEN }}" \
+            -H "Accept: application/vnd.github.v3+json" \
+            -d '{
+              "title": "[Release resourceapis patient ${{ steps.increment_patch_version.outputs.CURRENT_VERSION }}] Prepare for next dev cycle",
+              "body": "",
+              "head": "'"$HEAD_BRANCH"'",
+              "base": "'"$BASE_BRANCH"'"
+            }' \
+            "https://api.github.com/repos/${{ github.repository }}/pulls")
+          # Extract the pull request URL from the response
+          PR_URL=$(echo "$RESPONSE" | jq -r '.html_url')
+
+          echo "Pull Request created: $PR_URL"

--- a/.github/workflows/cd-resourceapis-practitioner.yml
+++ b/.github/workflows/cd-resourceapis-practitioner.yml
@@ -1,0 +1,140 @@
+name: CD - resourceapis Practitioner
+
+on:
+  workflow_dispatch:
+    inputs:
+      bal_central_environment:
+        description: Ballerina Central Environment
+        type: choice
+        options:
+        - STAGE
+        - DEV
+        - PROD
+        required: true
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    env:
+      JAVA_OPTS: -Xmx4G
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Ballerina Build Practitioner
+        uses: ballerina-platform/ballerina-action@2201.6.0
+        with:
+          args:
+            pack
+        env:
+          WORKING_DIR: ./r4/resource-apis/practitioner
+          JAVA_HOME: /usr/lib/jvm/default-jvm
+
+      - name: Push to Staging Practitioner
+        if: github.event.inputs.bal_central_environment == 'STAGE'
+        uses: ballerina-platform/ballerina-action@2201.6.0
+        with:
+          args:
+            push
+        env:
+          WORKING_DIR: ./r4/resource-apis/practitioner
+          JAVA_HOME: /usr/lib/jvm/default-jvm
+          BALLERINA_STAGE_CENTRAL: true
+          BALLERINA_CENTRAL_ACCESS_TOKEN: ${{ secrets.BALLERINA_CENTRAL_STAGE_ACCESS_TOKEN }}
+
+      - name: Push to Dev Practitioner
+        if: github.event.inputs.bal_central_environment == 'DEV'
+        uses: ballerina-platform/ballerina-action@2201.6.0
+        with:
+          args:
+            push
+        env:
+          WORKING_DIR: ./r4/resource-apis/practitioner
+          JAVA_HOME: /usr/lib/jvm/default-jvm
+          BALLERINA_DEV_CENTRAL: true
+          BALLERINA_CENTRAL_ACCESS_TOKEN: ${{ secrets.BALLERINA_CENTRAL_DEV_ACCESS_TOKEN }}      
+
+      - name: Push to Prod Practitioner
+        if: github.event.inputs.bal_central_environment == 'PROD'
+        uses: ballerina-platform/ballerina-action@2201.6.0
+        with:
+          args:
+            push
+        env:
+          WORKING_DIR: ./r4/resource-apis/practitioner
+          JAVA_HOME: /usr/lib/jvm/default-jvm
+          BALLERINA_CENTRAL_ACCESS_TOKEN: ${{ secrets.BALLERINA_CENTRAL_PROD_ACCESS_TOKEN }}
+
+      - name: Publish Release
+        if: github.event.inputs.bal_central_environment == 'PROD'
+        id: publish_release
+        run: |
+          # Get Branch Name
+          BRANCH_NAME=$(echo ${GITHUB_REF#refs/heads/})
+          echo "BRANCH_NAME=${BRANCH_NAME}" >> $GITHUB_OUTPUT
+          # Release name
+          RELEASE_NAME=${BRANCH_NAME#release-}
+          curl \
+            -s -X POST \
+            -H "Authorization: Bearer ${{ secrets.BALLERINA_BOT_TOKEN }}" \
+            -H "Accept: application/vnd.github.v3+json" \
+            -d '{
+              "tag_name": "'$RELEASE_NAME'",
+              "name": "'$RELEASE_NAME'",
+              "body": "[Automated] Creating tag:  '$RELEASE_NAME'.",
+              "draft": false,
+              "prerelease": false,
+              "target_commitish": "'$BRANCH_NAME'"
+            }' \
+            "https://api.github.com/repos/${{ github.repository }}/releases"
+
+      - name: Update version in Ballerina.toml
+        if: ${{ github.event.inputs.bal_central_environment == 'PROD' }}
+        id: increment_patch_version
+        run: |
+          CURRENT_VERSION=$(grep -Po -m 1 '(?<=version = ")[\d.]+' ./r4/resource-apis/practitioner/Ballerina.toml)
+          IFS='.' read -ra VERSION_PARTS <<< "$CURRENT_VERSION"
+          PATCH_VERSION=$((VERSION_PARTS[2] + 1))
+          NEW_VERSION="${VERSION_PARTS[0]}.${VERSION_PARTS[1]}.$PATCH_VERSION-snapshot"
+          sed -i "0,/version = \"${CURRENT_VERSION}\"/s//version = \"${NEW_VERSION}\"/" ./r4/resource-apis/practitioner/Ballerina.toml
+          echo "NEW_VERSION=${NEW_VERSION}" >> $GITHUB_OUTPUT
+          echo "CURRENT_VERSION=${CURRENT_VERSION}" >> $GITHUB_OUTPUT
+
+      - name: Ballerina Build after incrementing version
+        if: ${{ github.event.inputs.bal_central_environment == 'PROD' }}
+        uses: ballerina-platform/ballerina-action@2201.6.0
+        with:
+          args:
+            pack
+        env:
+          WORKING_DIR: ./r4/resource-apis/practitioner
+          JAVA_HOME: /usr/lib/jvm/default-jvm
+
+      - name: Commit changes and make a PR
+        if: ${{ github.event.inputs.bal_central_environment == 'PROD' }}
+        run: |
+          # Commit changes
+          git config --global user.name ${{ secrets.BALLERINA_BOT_USERNAME }}
+          git config --global user.email ${{ secrets.BALLERINA_BOT_EMAIL }}
+          git add ./r4/resource-apis/practitioner/Ballerina.toml
+          git add ./r4/resource-apis/practitioner/Dependencies.toml
+          git commit -m "[Release resourceapis practitioner ${{ steps.increment_patch_version.outputs.CURRENT_VERSION }}] Prepare for next dev cycle"
+          git push origin ${{ steps.publish_release.outputs.BRANCH_NAME }}
+          
+          # Set the base and head branches
+          BASE_BRANCH="main"
+          HEAD_BRANCH="${{ steps.publish_release.outputs.BRANCH_NAME }}"
+          # Create the pull request using the GitHub REST API
+          RESPONSE=$(curl -s -X POST \
+            -H "Authorization: Bearer ${{ secrets.BALLERINA_BOT_TOKEN }}" \
+            -H "Accept: application/vnd.github.v3+json" \
+            -d '{
+              "title": "[Release resourceapis practitioner ${{ steps.increment_patch_version.outputs.CURRENT_VERSION }}] Prepare for next dev cycle",
+              "body": "",
+              "head": "'"$HEAD_BRANCH"'",
+              "base": "'"$BASE_BRANCH"'"
+            }' \
+            "https://api.github.com/repos/${{ github.repository }}/pulls")
+          # Extract the pull request URL from the response
+          PR_URL=$(echo "$RESPONSE" | jq -r '.html_url')
+
+          echo "Pull Request created: $PR_URL"

--- a/.github/workflows/cd-resourceapis-serviceRequest.yml
+++ b/.github/workflows/cd-resourceapis-serviceRequest.yml
@@ -1,0 +1,140 @@
+name: CD - resourceapis Service Request
+
+on:
+  workflow_dispatch:
+    inputs:
+      bal_central_environment:
+        description: Ballerina Central Environment
+        type: choice
+        options:
+        - STAGE
+        - DEV
+        - PROD
+        required: true
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    env:
+      JAVA_OPTS: -Xmx4G
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Ballerina Build Service Request
+        uses: ballerina-platform/ballerina-action@2201.6.0
+        with:
+          args:
+            pack
+        env:
+          WORKING_DIR: ./r4/resource-apis/serviceRequest
+          JAVA_HOME: /usr/lib/jvm/default-jvm
+
+      - name: Push to Staging Service Request
+        if: github.event.inputs.bal_central_environment == 'STAGE'
+        uses: ballerina-platform/ballerina-action@2201.6.0
+        with:
+          args:
+            push
+        env:
+          WORKING_DIR: ./r4/resource-apis/serviceRequest
+          JAVA_HOME: /usr/lib/jvm/default-jvm
+          BALLERINA_STAGE_CENTRAL: true
+          BALLERINA_CENTRAL_ACCESS_TOKEN: ${{ secrets.BALLERINA_CENTRAL_STAGE_ACCESS_TOKEN }}
+
+      - name: Push to Dev Service Request
+        if: github.event.inputs.bal_central_environment == 'DEV'
+        uses: ballerina-platform/ballerina-action@2201.6.0
+        with:
+          args:
+            push
+        env:
+          WORKING_DIR: ./r4/resource-apis/serviceRequest
+          JAVA_HOME: /usr/lib/jvm/default-jvm
+          BALLERINA_DEV_CENTRAL: true
+          BALLERINA_CENTRAL_ACCESS_TOKEN: ${{ secrets.BALLERINA_CENTRAL_DEV_ACCESS_TOKEN }}      
+
+      - name: Push to Prod Service Request
+        if: github.event.inputs.bal_central_environment == 'PROD'
+        uses: ballerina-platform/ballerina-action@2201.6.0
+        with:
+          args:
+            push
+        env:
+          WORKING_DIR: ./r4/resource-apis/serviceRequest
+          JAVA_HOME: /usr/lib/jvm/default-jvm
+          BALLERINA_CENTRAL_ACCESS_TOKEN: ${{ secrets.BALLERINA_CENTRAL_PROD_ACCESS_TOKEN }}
+
+      - name: Publish Release
+        if: github.event.inputs.bal_central_environment == 'PROD'
+        id: publish_release
+        run: |
+          # Get Branch Name
+          BRANCH_NAME=$(echo ${GITHUB_REF#refs/heads/})
+          echo "BRANCH_NAME=${BRANCH_NAME}" >> $GITHUB_OUTPUT
+          # Release name
+          RELEASE_NAME=${BRANCH_NAME#release-}
+          curl \
+            -s -X POST \
+            -H "Authorization: Bearer ${{ secrets.BALLERINA_BOT_TOKEN }}" \
+            -H "Accept: application/vnd.github.v3+json" \
+            -d '{
+              "tag_name": "'$RELEASE_NAME'",
+              "name": "'$RELEASE_NAME'",
+              "body": "[Automated] Creating tag:  '$RELEASE_NAME'.",
+              "draft": false,
+              "prerelease": false,
+              "target_commitish": "'$BRANCH_NAME'"
+            }' \
+            "https://api.github.com/repos/${{ github.repository }}/releases"
+
+      - name: Update version in Ballerina.toml
+        if: ${{ github.event.inputs.bal_central_environment == 'PROD' }}
+        id: increment_patch_version
+        run: |
+          CURRENT_VERSION=$(grep -Po -m 1 '(?<=version = ")[\d.]+' ./r4/resource-apis/serviceRequest/Ballerina.toml)
+          IFS='.' read -ra VERSION_PARTS <<< "$CURRENT_VERSION"
+          PATCH_VERSION=$((VERSION_PARTS[2] + 1))
+          NEW_VERSION="${VERSION_PARTS[0]}.${VERSION_PARTS[1]}.$PATCH_VERSION-snapshot"
+          sed -i "0,/version = \"${CURRENT_VERSION}\"/s//version = \"${NEW_VERSION}\"/" ./r4/resource-apis/serviceRequest/Ballerina.toml
+          echo "NEW_VERSION=${NEW_VERSION}" >> $GITHUB_OUTPUT
+          echo "CURRENT_VERSION=${CURRENT_VERSION}" >> $GITHUB_OUTPUT
+
+      - name: Ballerina Build after incrementing version
+        if: ${{ github.event.inputs.bal_central_environment == 'PROD' }}
+        uses: ballerina-platform/ballerina-action@2201.6.0
+        with:
+          args:
+            pack
+        env:
+          WORKING_DIR: ./r4/resource-apis/serviceRequest
+          JAVA_HOME: /usr/lib/jvm/default-jvm
+
+      - name: Commit changes and make a PR
+        if: ${{ github.event.inputs.bal_central_environment == 'PROD' }}
+        run: |
+          # Commit changes
+          git config --global user.name ${{ secrets.BALLERINA_BOT_USERNAME }}
+          git config --global user.email ${{ secrets.BALLERINA_BOT_EMAIL }}
+          git add ./r4/resource-apis/serviceRequest/Ballerina.toml
+          git add ./r4/resource-apis/serviceRequest/Dependencies.toml
+          git commit -m "[Release resourceapis service request ${{ steps.increment_patch_version.outputs.CURRENT_VERSION }}] Prepare for next dev cycle"
+          git push origin ${{ steps.publish_release.outputs.BRANCH_NAME }}
+          
+          # Set the base and head branches
+          BASE_BRANCH="main"
+          HEAD_BRANCH="${{ steps.publish_release.outputs.BRANCH_NAME }}"
+          # Create the pull request using the GitHub REST API
+          RESPONSE=$(curl -s -X POST \
+            -H "Authorization: Bearer ${{ secrets.BALLERINA_BOT_TOKEN }}" \
+            -H "Accept: application/vnd.github.v3+json" \
+            -d '{
+              "title": "[Release resourceapis service request ${{ steps.increment_patch_version.outputs.CURRENT_VERSION }}] Prepare for next dev cycle",
+              "body": "",
+              "head": "'"$HEAD_BRANCH"'",
+              "base": "'"$BASE_BRANCH"'"
+            }' \
+            "https://api.github.com/repos/${{ github.repository }}/pulls")
+          # Extract the pull request URL from the response
+          PR_URL=$(echo "$RESPONSE" | jq -r '.html_url')
+
+          echo "Pull Request created: $PR_URL"

--- a/.github/workflows/cd-resourceapis-uscore501encounter.yml
+++ b/.github/workflows/cd-resourceapis-uscore501encounter.yml
@@ -1,0 +1,140 @@
+name: CD - resourceapis USCore501 Encounter 
+
+on:
+  workflow_dispatch:
+    inputs:
+      bal_central_environment:
+        description: Ballerina Central Environment
+        type: choice
+        options:
+        - STAGE
+        - DEV
+        - PROD
+        required: true
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    env:
+      JAVA_OPTS: -Xmx4G
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Ballerina Build USCore501 Encounter 
+        uses: ballerina-platform/ballerina-action@2201.6.0
+        with:
+          args:
+            pack
+        env:
+          WORKING_DIR: ./r4/resource-apis/uscore501-encounter
+          JAVA_HOME: /usr/lib/jvm/default-jvm
+
+      - name: Push to Staging USCore501 Encounter 
+        if: github.event.inputs.bal_central_environment == 'STAGE'
+        uses: ballerina-platform/ballerina-action@2201.6.0
+        with:
+          args:
+            push
+        env:
+          WORKING_DIR: ./r4/resource-apis/uscore501-encounter
+          JAVA_HOME: /usr/lib/jvm/default-jvm
+          BALLERINA_STAGE_CENTRAL: true
+          BALLERINA_CENTRAL_ACCESS_TOKEN: ${{ secrets.BALLERINA_CENTRAL_STAGE_ACCESS_TOKEN }}
+
+      - name: Push to Dev USCore501 Encounter 
+        if: github.event.inputs.bal_central_environment == 'DEV'
+        uses: ballerina-platform/ballerina-action@2201.6.0
+        with:
+          args:
+            push
+        env:
+          WORKING_DIR: ./r4/resource-apis/uscore501-encounter
+          JAVA_HOME: /usr/lib/jvm/default-jvm
+          BALLERINA_DEV_CENTRAL: true
+          BALLERINA_CENTRAL_ACCESS_TOKEN: ${{ secrets.BALLERINA_CENTRAL_DEV_ACCESS_TOKEN }}      
+
+      - name: Push to Prod USCore501 Encounter 
+        if: github.event.inputs.bal_central_environment == 'PROD'
+        uses: ballerina-platform/ballerina-action@2201.6.0
+        with:
+          args:
+            push
+        env:
+          WORKING_DIR: ./r4/resource-apis/uscore501-encounter
+          JAVA_HOME: /usr/lib/jvm/default-jvm
+          BALLERINA_CENTRAL_ACCESS_TOKEN: ${{ secrets.BALLERINA_CENTRAL_PROD_ACCESS_TOKEN }}
+
+      - name: Publish Release
+        if: github.event.inputs.bal_central_environment == 'PROD'
+        id: publish_release
+        run: |
+          # Get Branch Name
+          BRANCH_NAME=$(echo ${GITHUB_REF#refs/heads/})
+          echo "BRANCH_NAME=${BRANCH_NAME}" >> $GITHUB_OUTPUT
+          # Release name
+          RELEASE_NAME=${BRANCH_NAME#release-}
+          curl \
+            -s -X POST \
+            -H "Authorization: Bearer ${{ secrets.BALLERINA_BOT_TOKEN }}" \
+            -H "Accept: application/vnd.github.v3+json" \
+            -d '{
+              "tag_name": "'$RELEASE_NAME'",
+              "name": "'$RELEASE_NAME'",
+              "body": "[Automated] Creating tag:  '$RELEASE_NAME'.",
+              "draft": false,
+              "prerelease": false,
+              "target_commitish": "'$BRANCH_NAME'"
+            }' \
+            "https://api.github.com/repos/${{ github.repository }}/releases"
+
+      - name: Update version in Ballerina.toml
+        if: ${{ github.event.inputs.bal_central_environment == 'PROD' }}
+        id: increment_patch_version
+        run: |
+          CURRENT_VERSION=$(grep -Po -m 1 '(?<=version = ")[\d.]+' ./r4/resource-apis/uscore501-encounter/Ballerina.toml)
+          IFS='.' read -ra VERSION_PARTS <<< "$CURRENT_VERSION"
+          PATCH_VERSION=$((VERSION_PARTS[2] + 1))
+          NEW_VERSION="${VERSION_PARTS[0]}.${VERSION_PARTS[1]}.$PATCH_VERSION-snapshot"
+          sed -i "0,/version = \"${CURRENT_VERSION}\"/s//version = \"${NEW_VERSION}\"/" ./r4/resource-apis/uscore501-encounter/Ballerina.toml
+          echo "NEW_VERSION=${NEW_VERSION}" >> $GITHUB_OUTPUT
+          echo "CURRENT_VERSION=${CURRENT_VERSION}" >> $GITHUB_OUTPUT
+
+      - name: Ballerina Build after incrementing version
+        if: ${{ github.event.inputs.bal_central_environment == 'PROD' }}
+        uses: ballerina-platform/ballerina-action@2201.6.0
+        with:
+          args:
+            pack
+        env:
+          WORKING_DIR: ./r4/resource-apis/uscore501-encounter
+          JAVA_HOME: /usr/lib/jvm/default-jvm
+
+      - name: Commit changes and make a PR
+        if: ${{ github.event.inputs.bal_central_environment == 'PROD' }}
+        run: |
+          # Commit changes
+          git config --global user.name ${{ secrets.BALLERINA_BOT_USERNAME }}
+          git config --global user.email ${{ secrets.BALLERINA_BOT_EMAIL }}
+          git add ./r4/resource-apis/uscore501-encounter/Ballerina.toml
+          git add ./r4/resource-apis/uscore501-encounter/Dependencies.toml
+          git commit -m "[Release resourceapis uscore501 encounter  ${{ steps.increment_patch_version.outputs.CURRENT_VERSION }}] Prepare for next dev cycle"
+          git push origin ${{ steps.publish_release.outputs.BRANCH_NAME }}
+          
+          # Set the base and head branches
+          BASE_BRANCH="main"
+          HEAD_BRANCH="${{ steps.publish_release.outputs.BRANCH_NAME }}"
+          # Create the pull request using the GitHub REST API
+          RESPONSE=$(curl -s -X POST \
+            -H "Authorization: Bearer ${{ secrets.BALLERINA_BOT_TOKEN }}" \
+            -H "Accept: application/vnd.github.v3+json" \
+            -d '{
+              "title": "[Release resourceapis uscore501 encounter  ${{ steps.increment_patch_version.outputs.CURRENT_VERSION }}] Prepare for next dev cycle",
+              "body": "",
+              "head": "'"$HEAD_BRANCH"'",
+              "base": "'"$BASE_BRANCH"'"
+            }' \
+            "https://api.github.com/repos/${{ github.repository }}/pulls")
+          # Extract the pull request URL from the response
+          PR_URL=$(echo "$RESPONSE" | jq -r '.html_url')
+
+          echo "Pull Request created: $PR_URL"

--- a/.github/workflows/cd-resourceapis-uscore501patient.yml
+++ b/.github/workflows/cd-resourceapis-uscore501patient.yml
@@ -1,0 +1,140 @@
+name: CD - resourceapis USCore501 Patient
+
+on:
+  workflow_dispatch:
+    inputs:
+      bal_central_environment:
+        description: Ballerina Central Environment
+        type: choice
+        options:
+        - STAGE
+        - DEV
+        - PROD
+        required: true
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    env:
+      JAVA_OPTS: -Xmx4G
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Ballerina Build USCore501 Patient
+        uses: ballerina-platform/ballerina-action@2201.6.0
+        with:
+          args:
+            pack
+        env:
+          WORKING_DIR: ./r4/resource-apis/uscore501-patient
+          JAVA_HOME: /usr/lib/jvm/default-jvm
+
+      - name: Push to Staging USCore501 Patient
+        if: github.event.inputs.bal_central_environment == 'STAGE'
+        uses: ballerina-platform/ballerina-action@2201.6.0
+        with:
+          args:
+            push
+        env:
+          WORKING_DIR: ./r4/resource-apis/uscore501-patient
+          JAVA_HOME: /usr/lib/jvm/default-jvm
+          BALLERINA_STAGE_CENTRAL: true
+          BALLERINA_CENTRAL_ACCESS_TOKEN: ${{ secrets.BALLERINA_CENTRAL_STAGE_ACCESS_TOKEN }}
+
+      - name: Push to Dev USCore501 Patient
+        if: github.event.inputs.bal_central_environment == 'DEV'
+        uses: ballerina-platform/ballerina-action@2201.6.0
+        with:
+          args:
+            push
+        env:
+          WORKING_DIR: ./r4/resource-apis/uscore501-patient
+          JAVA_HOME: /usr/lib/jvm/default-jvm
+          BALLERINA_DEV_CENTRAL: true
+          BALLERINA_CENTRAL_ACCESS_TOKEN: ${{ secrets.BALLERINA_CENTRAL_DEV_ACCESS_TOKEN }}      
+
+      - name: Push to Prod USCore501 Patient
+        if: github.event.inputs.bal_central_environment == 'PROD'
+        uses: ballerina-platform/ballerina-action@2201.6.0
+        with:
+          args:
+            push
+        env:
+          WORKING_DIR: ./r4/resource-apis/uscore501-patient
+          JAVA_HOME: /usr/lib/jvm/default-jvm
+          BALLERINA_CENTRAL_ACCESS_TOKEN: ${{ secrets.BALLERINA_CENTRAL_PROD_ACCESS_TOKEN }}
+
+      - name: Publish Release
+        if: github.event.inputs.bal_central_environment == 'PROD'
+        id: publish_release
+        run: |
+          # Get Branch Name
+          BRANCH_NAME=$(echo ${GITHUB_REF#refs/heads/})
+          echo "BRANCH_NAME=${BRANCH_NAME}" >> $GITHUB_OUTPUT
+          # Release name
+          RELEASE_NAME=${BRANCH_NAME#release-}
+          curl \
+            -s -X POST \
+            -H "Authorization: Bearer ${{ secrets.BALLERINA_BOT_TOKEN }}" \
+            -H "Accept: application/vnd.github.v3+json" \
+            -d '{
+              "tag_name": "'$RELEASE_NAME'",
+              "name": "'$RELEASE_NAME'",
+              "body": "[Automated] Creating tag:  '$RELEASE_NAME'.",
+              "draft": false,
+              "prerelease": false,
+              "target_commitish": "'$BRANCH_NAME'"
+            }' \
+            "https://api.github.com/repos/${{ github.repository }}/releases"
+
+      - name: Update version in Ballerina.toml
+        if: ${{ github.event.inputs.bal_central_environment == 'PROD' }}
+        id: increment_patch_version
+        run: |
+          CURRENT_VERSION=$(grep -Po -m 1 '(?<=version = ")[\d.]+' ./r4/resource-apis/uscore501-patient/Ballerina.toml)
+          IFS='.' read -ra VERSION_PARTS <<< "$CURRENT_VERSION"
+          PATCH_VERSION=$((VERSION_PARTS[2] + 1))
+          NEW_VERSION="${VERSION_PARTS[0]}.${VERSION_PARTS[1]}.$PATCH_VERSION-snapshot"
+          sed -i "0,/version = \"${CURRENT_VERSION}\"/s//version = \"${NEW_VERSION}\"/" ./r4/resource-apis/uscore501-patient/Ballerina.toml
+          echo "NEW_VERSION=${NEW_VERSION}" >> $GITHUB_OUTPUT
+          echo "CURRENT_VERSION=${CURRENT_VERSION}" >> $GITHUB_OUTPUT
+
+      - name: Ballerina Build after incrementing version
+        if: ${{ github.event.inputs.bal_central_environment == 'PROD' }}
+        uses: ballerina-platform/ballerina-action@2201.6.0
+        with:
+          args:
+            pack
+        env:
+          WORKING_DIR: ./r4/resource-apis/uscore501-patient
+          JAVA_HOME: /usr/lib/jvm/default-jvm
+
+      - name: Commit changes and make a PR
+        if: ${{ github.event.inputs.bal_central_environment == 'PROD' }}
+        run: |
+          # Commit changes
+          git config --global user.name ${{ secrets.BALLERINA_BOT_USERNAME }}
+          git config --global user.email ${{ secrets.BALLERINA_BOT_EMAIL }}
+          git add ./r4/resource-apis/uscore501-patient/Ballerina.toml
+          git add ./r4/resource-apis/uscore501-patient/Dependencies.toml
+          git commit -m "[Release resourceapis uscore501 patient ${{ steps.increment_patch_version.outputs.CURRENT_VERSION }}] Prepare for next dev cycle"
+          git push origin ${{ steps.publish_release.outputs.BRANCH_NAME }}
+          
+          # Set the base and head branches
+          BASE_BRANCH="main"
+          HEAD_BRANCH="${{ steps.publish_release.outputs.BRANCH_NAME }}"
+          # Create the pull request using the GitHub REST API
+          RESPONSE=$(curl -s -X POST \
+            -H "Authorization: Bearer ${{ secrets.BALLERINA_BOT_TOKEN }}" \
+            -H "Accept: application/vnd.github.v3+json" \
+            -d '{
+              "title": "[Release resourceapis uscore501 patient ${{ steps.increment_patch_version.outputs.CURRENT_VERSION }}] Prepare for next dev cycle",
+              "body": "",
+              "head": "'"$HEAD_BRANCH"'",
+              "base": "'"$BASE_BRANCH"'"
+            }' \
+            "https://api.github.com/repos/${{ github.repository }}/pulls")
+          # Extract the pull request URL from the response
+          PR_URL=$(echo "$RESPONSE" | jq -r '.html_url')
+
+          echo "Pull Request created: $PR_URL"

--- a/.github/workflows/cd-smartconfig.yml
+++ b/.github/workflows/cd-smartconfig.yml
@@ -1,0 +1,140 @@
+name: CD - resourceapis Smart Config
+
+on:
+  workflow_dispatch:
+    inputs:
+      bal_central_environment:
+        description: Ballerina Central Environment
+        type: choice
+        options:
+        - STAGE
+        - DEV
+        - PROD
+        required: true
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    env:
+      JAVA_OPTS: -Xmx4G
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Ballerina Build Smart Config
+        uses: ballerina-platform/ballerina-action@2201.6.0
+        with:
+          args:
+            pack
+        env:
+          WORKING_DIR: ./r4/smartconfig
+          JAVA_HOME: /usr/lib/jvm/default-jvm
+
+      - name: Push to Staging Smart Config
+        if: github.event.inputs.bal_central_environment == 'STAGE'
+        uses: ballerina-platform/ballerina-action@2201.6.0
+        with:
+          args:
+            push
+        env:
+          WORKING_DIR: ./r4/smartconfig
+          JAVA_HOME: /usr/lib/jvm/default-jvm
+          BALLERINA_STAGE_CENTRAL: true
+          BALLERINA_CENTRAL_ACCESS_TOKEN: ${{ secrets.BALLERINA_CENTRAL_STAGE_ACCESS_TOKEN }}
+
+      - name: Push to Dev Smart Config
+        if: github.event.inputs.bal_central_environment == 'DEV'
+        uses: ballerina-platform/ballerina-action@2201.6.0
+        with:
+          args:
+            push
+        env:
+          WORKING_DIR: ./r4/smartconfig
+          JAVA_HOME: /usr/lib/jvm/default-jvm
+          BALLERINA_DEV_CENTRAL: true
+          BALLERINA_CENTRAL_ACCESS_TOKEN: ${{ secrets.BALLERINA_CENTRAL_DEV_ACCESS_TOKEN }}      
+
+      - name: Push to Prod Smart Config
+        if: github.event.inputs.bal_central_environment == 'PROD'
+        uses: ballerina-platform/ballerina-action@2201.6.0
+        with:
+          args:
+            push
+        env:
+          WORKING_DIR: ./r4/smartconfig
+          JAVA_HOME: /usr/lib/jvm/default-jvm
+          BALLERINA_CENTRAL_ACCESS_TOKEN: ${{ secrets.BALLERINA_CENTRAL_PROD_ACCESS_TOKEN }}
+
+      - name: Publish Release
+        if: github.event.inputs.bal_central_environment == 'PROD'
+        id: publish_release
+        run: |
+          # Get Branch Name
+          BRANCH_NAME=$(echo ${GITHUB_REF#refs/heads/})
+          echo "BRANCH_NAME=${BRANCH_NAME}" >> $GITHUB_OUTPUT
+          # Release name
+          RELEASE_NAME=${BRANCH_NAME#release-}
+          curl \
+            -s -X POST \
+            -H "Authorization: Bearer ${{ secrets.BALLERINA_BOT_TOKEN }}" \
+            -H "Accept: application/vnd.github.v3+json" \
+            -d '{
+              "tag_name": "'$RELEASE_NAME'",
+              "name": "'$RELEASE_NAME'",
+              "body": "[Automated] Creating tag:  '$RELEASE_NAME'.",
+              "draft": false,
+              "prerelease": false,
+              "target_commitish": "'$BRANCH_NAME'"
+            }' \
+            "https://api.github.com/repos/${{ github.repository }}/releases"
+
+      - name: Update version in Ballerina.toml
+        if: ${{ github.event.inputs.bal_central_environment == 'PROD' }}
+        id: increment_patch_version
+        run: |
+          CURRENT_VERSION=$(grep -Po -m 1 '(?<=version = ")[\d.]+' ./r4/smartconfig/Ballerina.toml)
+          IFS='.' read -ra VERSION_PARTS <<< "$CURRENT_VERSION"
+          PATCH_VERSION=$((VERSION_PARTS[2] + 1))
+          NEW_VERSION="${VERSION_PARTS[0]}.${VERSION_PARTS[1]}.$PATCH_VERSION-snapshot"
+          sed -i "0,/version = \"${CURRENT_VERSION}\"/s//version = \"${NEW_VERSION}\"/" ./r4/smartconfig/Ballerina.toml
+          echo "NEW_VERSION=${NEW_VERSION}" >> $GITHUB_OUTPUT
+          echo "CURRENT_VERSION=${CURRENT_VERSION}" >> $GITHUB_OUTPUT
+
+      - name: Ballerina Build after incrementing version
+        if: ${{ github.event.inputs.bal_central_environment == 'PROD' }}
+        uses: ballerina-platform/ballerina-action@2201.6.0
+        with:
+          args:
+            pack
+        env:
+          WORKING_DIR: ./r4/smartconfig
+          JAVA_HOME: /usr/lib/jvm/default-jvm
+
+      - name: Commit changes and make a PR
+        if: ${{ github.event.inputs.bal_central_environment == 'PROD' }}
+        run: |
+          # Commit changes
+          git config --global user.name ${{ secrets.BALLERINA_BOT_USERNAME }}
+          git config --global user.email ${{ secrets.BALLERINA_BOT_EMAIL }}
+          git add ./r4/smartconfig/Ballerina.toml
+          git add ./r4/smartconfig/Dependencies.toml
+          git commit -m "[Release resourceapis smart config ${{ steps.increment_patch_version.outputs.CURRENT_VERSION }}] Prepare for next dev cycle"
+          git push origin ${{ steps.publish_release.outputs.BRANCH_NAME }}
+          
+          # Set the base and head branches
+          BASE_BRANCH="main"
+          HEAD_BRANCH="${{ steps.publish_release.outputs.BRANCH_NAME }}"
+          # Create the pull request using the GitHub REST API
+          RESPONSE=$(curl -s -X POST \
+            -H "Authorization: Bearer ${{ secrets.BALLERINA_BOT_TOKEN }}" \
+            -H "Accept: application/vnd.github.v3+json" \
+            -d '{
+              "title": "[Release resourceapis smart config ${{ steps.increment_patch_version.outputs.CURRENT_VERSION }}] Prepare for next dev cycle",
+              "body": "",
+              "head": "'"$HEAD_BRANCH"'",
+              "base": "'"$BASE_BRANCH"'"
+            }' \
+            "https://api.github.com/repos/${{ github.repository }}/pulls")
+          # Extract the pull request URL from the response
+          PR_URL=$(echo "$RESPONSE" | jq -r '.html_url')
+
+          echo "Pull Request created: $PR_URL"

--- a/.github/workflows/cd-smartconfig.yml
+++ b/.github/workflows/cd-smartconfig.yml
@@ -1,4 +1,4 @@
-name: CD - resourceapis Smart Config
+name: CD - Smart Config
 
 on:
   workflow_dispatch:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,123 @@
+name: CI
+
+on:
+  pull_request:
+    types:
+      - opened
+      - synchronize
+
+env:
+  R4_RESOURCE_APIS_PATTERN: r4/resource-apis/*/*
+  R4_PATTERN: r4/*/*
+
+jobs:
+  setup:
+    runs-on: ubuntu-latest
+    outputs:
+      project-matrix: ${{ steps.unique-project-paths.outputs.BALLERINA_PROJECT_PATHS }}
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+
+      - name: Extract Unique Ballerina Project Paths from Changed Files
+        id: unique-project-paths
+        run: |
+          # Get changed files of PR from github API
+          PR_DETAILS=$(curl -sSL \
+            "https://api.github.com/repos/${{ github.repository }}/pulls/${{ github.event.pull_request.number }}/files")
+          CHANGED_FILES=$(echo "$PR_DETAILS" | jq -r '.[].filename')
+          echo "Changed Files: "
+          echo "${CHANGED_FILES}"
+
+          # Convert CHANGED_FILES to an array
+          readarray -t CHANGED_FILES_ARRAY <<<"${CHANGED_FILES}"
+          
+          # Remove duplicates from the CHANGED_FILES_ARRAY
+          declare -A UNIQUE_PATHS_MAP
+          for file in "${CHANGED_FILES_ARRAY[@]}"; do
+            if [[ $file == $R4_RESOURCE_APIS_PATTERN ]]; then
+              EXTRACTED_PATH=$(echo "$file" | cut -d '/' -f 1-3)
+            elif [[ $file == $R4_PATTERN ]]; then
+              EXTRACTED_PATH=$(echo "$file" | cut -d '/' -f 1-2)
+            fi
+
+            if [[ $EXTRACTED_PATH ]]; then
+              UNIQUE_PATHS_MAP[$EXTRACTED_PATH]=1
+            fi
+          done
+          
+          # Print the unique ballerina project paths
+          echo "Extracted Unique Ballerina Project Paths: "
+          for EXTRACTED_PATH in "${!UNIQUE_PATHS_MAP[@]}"; do
+            echo "$EXTRACTED_PATH"
+          done
+
+          # Create the JSON array with elements enclosed in double quotes
+          UNIQUE_PATHS_JSON=$(for key in "${!UNIQUE_PATHS_MAP[@]}"; do echo "\"$key\""; done | jq -s -c .)
+          echo "UNIQUE_PATHS_JSON: "
+          echo "${UNIQUE_PATHS_JSON}"
+          echo "BALLERINA_PROJECT_PATHS=${UNIQUE_PATHS_JSON}" >> $GITHUB_OUTPUT
+
+  build:
+    needs: [ setup ]
+    runs-on: ubuntu-latest
+    env:
+      JAVA_OPTS: -Xmx4G
+    if: ${{ needs.setup.outputs.project-matrix != '[]' }}
+    strategy:
+      matrix:
+        path: ${{ fromJson(needs.setup.outputs.project-matrix) }}
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+
+      - name: Ballerina Build
+        uses: ballerina-platform/ballerina-action@2201.6.0
+        with:
+          args: pack
+        env:
+          WORKING_DIR: ./${{ matrix.path }}
+          JAVA_HOME: /usr/lib/jvm/default-jvm
+
+  test:
+    needs: [ setup ]
+    runs-on: ubuntu-latest
+    env:
+      JAVA_OPTS: -Xmx4G
+    if: ${{ needs.setup.outputs.project-matrix != '[]' }}
+    strategy:
+      matrix:
+        path: ${{ fromJson(needs.setup.outputs.project-matrix) }}
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+
+      - name: Ballerina Test
+        uses: ballerina-platform/ballerina-action@2201.6.0
+        with:
+          args: test --code-coverage
+        env:
+          WORKING_DIR: ./${{ matrix.path }}
+          JAVA_HOME: /usr/lib/jvm/default-jvm
+
+      - name: Read Ballerina Test Results
+        id: test_results
+        run: |
+          if [ -f "./${{ matrix.path }}/target/report/test_results.json" ]; then
+            content=`cat ./${{ matrix.path }}/target/report/test_results.json`                
+            content="${content//'%'/'%25'}"
+            content="${content//$'\n'/'%0A'}"
+            content="${content//$'\r'/'%0D'}"
+
+            echo "Covered Code Lines : $(echo "$content" | jq -r '.coveredLines')"
+            echo "Total Code Lines : $(echo "$content" | jq -r '.missedLines') + $(echo "$content" | jq -r '.coveredLines')"
+            echo "Code Coverage Percentage : $(echo "$content" | jq -r '.coveragePercentage')"
+          else
+            # echo "TEST_RESULTS_JSON=" >> $GITHUB_OUTPUT
+            echo "No test results file found."
+          fi

--- a/r4/resource-apis/diagnosticReport/tests/service_test.bal
+++ b/r4/resource-apis/diagnosticReport/tests/service_test.bal
@@ -1,1 +1,0 @@
-//Tests for DiagnosticReportAPI will be added here.

--- a/r4/resource-apis/encounter/tests/service_test.bal
+++ b/r4/resource-apis/encounter/tests/service_test.bal
@@ -1,1 +1,0 @@
-//Tests for EncounterAPI will be added here.

--- a/r4/resource-apis/observation/tests/service_test.bal
+++ b/r4/resource-apis/observation/tests/service_test.bal
@@ -1,1 +1,0 @@
-//Tests for ObservationAPI will be added here.

--- a/r4/resource-apis/organization/tests/service_test.bal
+++ b/r4/resource-apis/organization/tests/service_test.bal
@@ -1,1 +1,0 @@
-//Tests for OrganizationAPI will be added here.

--- a/r4/resource-apis/patient/tests/service_test.bal
+++ b/r4/resource-apis/patient/tests/service_test.bal
@@ -1,1 +1,0 @@
-//Tests for PatientAPI will be added here.

--- a/r4/resource-apis/practitioner/tests/service_test.bal
+++ b/r4/resource-apis/practitioner/tests/service_test.bal
@@ -1,1 +1,0 @@
-//Tests for PractitionerAPI will be added here.

--- a/r4/resource-apis/serviceRequest/tests/service_test.bal
+++ b/r4/resource-apis/serviceRequest/tests/service_test.bal
@@ -1,1 +1,0 @@
-//Tests for ServiceRequestAPI will be added here.

--- a/r4/resource-apis/uscore501-encounter/tests/service_test.bal
+++ b/r4/resource-apis/uscore501-encounter/tests/service_test.bal
@@ -1,1 +1,0 @@
-//Tests for USCoreEncounterProfileAPI will be added here.

--- a/r4/resource-apis/uscore501-patient/tests/service_test.bal
+++ b/r4/resource-apis/uscore501-patient/tests/service_test.bal
@@ -1,1 +1,0 @@
-//Tests for PatientAPI will be added here.


### PR DESCRIPTION
Related Issue: https://github.com/wso2-enterprise/open-healthcare/issues/1200

## Purpose
> Implement CI-CD pipelines for templates

## Goals
> Automate ballerina build and running tests on a PR
> Automate the release of ballerina artifacts to ballerina central's STAGE, DEV, and PROD environments

## Approach
> Implement a single CI workflow that triggers on every pull request and extracts the paths of all ballerina templates with changes from the respective pull request. This workflow handles the build process and executes unit tests for each identified template.
> Implement individual CD workflows for each Ballerina template, which can be manually triggered. These workflows are responsible for the building and releasing process to a chosen environment within Ballerina Central.

## Documentation
> https://docs.google.com/document/d/17-j7xDraMf_xO4B5_VziXpbmkgV_dPWypHONfxgkbRA/edit?usp=sharing 