### PR TITLE
Improve fhir apis cd

### DIFF
--- a/.github/workflows/cd-resourceapis.yml
+++ b/.github/workflows/cd-resourceapis.yml
@@ -1,4 +1,4 @@
-name: Release FHIR API Templates
+name: CD - FHIR API Templates
 
 on:
   workflow_dispatch:
@@ -30,13 +30,57 @@ jobs:
 
   release:
     needs: [findpaths]
-    if: ${{ needs.findpaths.outputs.subdirectories != '[]' }}}}
+    runs-on: ubuntu-latest
+    if: ${{ needs.findpaths.outputs.subdirectories != '[]' }}
     strategy:
+      fail-fast: false
       matrix:
         path: ${{ fromJSON(needs.findpaths.outputs.subdirectories) }}
-    uses: ./.github/workflows/build-executor.yml
-    secrets: inherit
-    with:
-      bal_central_environment: ${{ inputs.bal_central_environment }}
-      working_dir: ${{ matrix.path }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
 
+      - name: Run ballerina build for dev
+        if: inputs.bal_central_environment == 'DEV'
+        uses: ballerina-platform/ballerina-action@2201.8.1
+        with:
+          args:
+            pack
+        env:
+          WORKING_DIR: ${{ matrix.path }}
+          JAVA_HOME: /usr/lib/jvm/default-jvm 
+          BALLERINA_DEV_CENTRAL: true
+          BALLERINA_CENTRAL_ACCESS_TOKEN: ${{ secrets.BALLERINA_CENTRAL_DEV_ACCESS_TOKEN }} 
+
+      - name: Run ballerina build for prod
+        if: inputs.bal_central_environment == 'PROD'
+        uses: ballerina-platform/ballerina-action@2201.8.1
+        with:
+          args:
+            pack
+        env:
+          WORKING_DIR: ${{ matrix.path }}
+          JAVA_HOME: /usr/lib/jvm/default-jvm 
+
+      - name: Push to Dev
+        if: inputs.bal_central_environment == 'DEV'
+        uses: ballerina-platform/ballerina-action@2201.8.1
+        with:
+          args:
+            push
+        env:
+          WORKING_DIR: ${{ matrix.path }}
+          JAVA_HOME: /usr/lib/jvm/default-jvm
+          BALLERINA_DEV_CENTRAL: true
+          BALLERINA_CENTRAL_ACCESS_TOKEN: ${{ secrets.BALLERINA_CENTRAL_DEV_ACCESS_TOKEN }}     
+
+      - name: Push to Prod
+        if: inputs.bal_central_environment == 'PROD'
+        uses: ballerina-platform/ballerina-action@2201.8.1
+        with:
+          args:
+            push
+        env:
+          WORKING_DIR: ${{ matrix.path }}
+          JAVA_HOME: /usr/lib/jvm/default-jvm
+          BALLERINA_CENTRAL_ACCESS_TOKEN: ${{ secrets.BALLERINA_CENTRAL_ACCESS_TOKEN }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,7 +25,7 @@ jobs:
       - name: Extract Unique Ballerina Project Paths from Changed Files
         id: unique-project-paths
         env:
-          GITHUB_TOKEN: ${{ secrets.BALLERINA_BOT_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           # Get changed files of PR from github API
           CHANGED_FILES=$(gh api graphql -f query='


### PR DESCRIPTION
- Make matrix jobs continue even if a job fails.
- Add building and push to central steps and remove the reusable workflow, since the github release part is not needed for this.